### PR TITLE
fix: unify LeadOrbit backend branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Lime
+# LeadOrbit
 
-Current branding note: the repo and backend still use `Lime` in a few places, but the frontend UI is mostly branded as `LeadOrbit`.
+Current branding note: the active app is branded as `LeadOrbit`; older planning documents in the repo may still mention the original `Lime` name.
 
-Lime is a multi-tenant outbound outreach MVP built with Django REST Framework and a static HTML/JavaScript frontend. The implemented code supports organization signup, JWT auth, CSV lead import, campaign building, lead enrollment, Gmail sender connection, AI-assisted email drafting, webhook-based engagement tracking, and analytics pages.
+LeadOrbit is a multi-tenant outbound outreach MVP built with Django REST Framework and a static HTML/JavaScript frontend. The implemented code supports organization signup, JWT auth, CSV lead import, campaign building, lead enrollment, Gmail sender connection, AI-assisted email drafting, webhook-based engagement tracking, and analytics pages.
 
 This README is based on the current codebase, not the older planning documents in the repo root.
 
@@ -90,7 +90,7 @@ LAUNCH_IMMEDIATE_PASSES=1
 OPENROUTER_API_KEY=
 OPENROUTER_MODEL=mistralai/mistral-nemo
 OPENROUTER_APP_URL=http://127.0.0.1:8080
-OPENROUTER_APP_NAME=Lime Campaign Builder
+OPENROUTER_APP_NAME=LeadOrbit Campaign Builder
 
 GEMINI_API_KEY=
 
@@ -198,7 +198,7 @@ Current repo state: `27` backend tests pass. The suite covers auth/profile updat
 
 ## Current Caveats
 
-- Branding is inconsistent: the UI mostly says `LeadOrbit`, while parts of the backend and settings still say `Lime`.
+- Some older root planning documents still mention the original `Lime` name, but the active README, backend, and frontend runtime paths use `LeadOrbit`.
 - The settings page shows a Gemini API key field, but it is not persisted from the UI. AI credentials are read from `backend/.env`.
 - The danger-zone buttons in `settings.html` are presentational only right now.
 - [`frontend/src`](frontend/src) and [`backend/config`](backend/config) look like leftover scaffold code and are not part of the main runtime path.

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -179,7 +179,7 @@ GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', _read_local_env_value('GEMINI_API_K
 OPENROUTER_API_KEY = os.getenv('OPENROUTER_API_KEY', _read_local_env_value('OPENROUTER_API_KEY', ''))
 OPENROUTER_MODEL = os.getenv('OPENROUTER_MODEL', _read_local_env_value('OPENROUTER_MODEL', 'mistralai/mistral-nemo'))
 OPENROUTER_APP_URL = os.getenv('OPENROUTER_APP_URL', _read_local_env_value('OPENROUTER_APP_URL', 'http://localhost:8080'))
-OPENROUTER_APP_NAME = os.getenv('OPENROUTER_APP_NAME', _read_local_env_value('OPENROUTER_APP_NAME', 'Lime Campaign Builder'))
+OPENROUTER_APP_NAME = os.getenv('OPENROUTER_APP_NAME', _read_local_env_value('OPENROUTER_APP_NAME', 'LeadOrbit Campaign Builder'))
 
 # Reply detection toggle (used by Gmail polling task)
 ENABLE_AUTO_REPLY_DETECTION = os.getenv(

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -18,7 +18,7 @@ from campaigns.google_auth_views import GoogleOAuthLoginView, GoogleOAuthCallbac
 def api_root(_request):
     return JsonResponse({
         'status': 'ok',
-        'service': 'Lime backend API',
+        'service': 'LeadOrbit backend API',
         'base_path': '/api/v1/',
     })
 
@@ -44,5 +44,4 @@ urlpatterns = [
     path('api/v1/connected-accounts/', ConnectedAccountsListView.as_view(), name='connected_accounts'),
     path('api/v1/', include(router.urls)),
 ]
-
 

--- a/backend/campaigns/ai.py
+++ b/backend/campaigns/ai.py
@@ -97,7 +97,7 @@ def generate_email_chat_completion(prompt, current_subject='', current_body='', 
         raise ValueError('A prompt is required.')
 
     system_prompt = (
-        'You are Lime AI, an expert outbound email assistant for B2B sales teams. '
+        'You are LeadOrbit AI, an expert outbound email assistant for B2B sales teams. '
         'The user will describe what kind of email they want. '
         'Pay close attention to every detail in the user\'s prompt — company names, '
         'product descriptions, value propositions, tone requests, and any specific '
@@ -145,7 +145,7 @@ def generate_email_chat_completion(prompt, current_subject='', current_body='', 
                     'Authorization': f'Bearer {openrouter_api_key}',
                     'Content-Type': 'application/json',
                     'HTTP-Referer': getattr(settings, 'OPENROUTER_APP_URL', 'http://localhost:8080'),
-                    'X-Title': getattr(settings, 'OPENROUTER_APP_NAME', 'Lime Campaign Builder'),
+                    'X-Title': getattr(settings, 'OPENROUTER_APP_NAME', 'LeadOrbit Campaign Builder'),
                 },
                 json={
                     'model': _get_openrouter_model(),


### PR DESCRIPTION
## Summary
- Rename the backend API root service label from Lime to LeadOrbit
- Update the outbound AI assistant system prompt and OpenRouter title fallback to LeadOrbit
- Align the README setup/default branding text with the active LeadOrbit runtime paths

## Validation
- `python3 -m py_compile backend/backend/urls.py backend/backend/settings.py backend/campaigns/ai.py`
- `uv run --with-requirements ../requirements.txt python manage.py test` from `backend/` (27 tests passed)
- `git diff --check`

Closes #23
