### PR TITLE
feat: wire settings danger zone actions

### DIFF
--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -80,3 +80,11 @@ class LeadIsolationAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         created = Lead.objects.get(email='new-orgb-lead@example.com')
         self.assertEqual(created.organization_id, self.org_b.id)
+
+    def test_delete_all_removes_only_current_users_organization_leads(self):
+        self.client.force_authenticate(self.user_a)
+        response = self.client.delete('/api/v1/leads/delete-all/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Lead.objects.filter(id=self.lead_a.id).exists())
+        self.assertTrue(Lead.objects.filter(id=self.lead_b.id).exists())

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -15,6 +15,14 @@ class LeadViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(organization=self.request.user.organization)
 
+    @action(detail=False, methods=['delete'], url_path='delete-all')
+    def delete_all(self, request):
+        deleted_count, _ = self.get_queryset().delete()
+        return Response(
+            {"message": f"Successfully deleted {deleted_count} leads."},
+            status=status.HTTP_200_OK,
+        )
+
     @action(detail=False, methods=['post'], parser_classes=[parsers.MultiPartParser])
     def import_csv(self, request):
         file_obj = request.FILES.get('file')

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -35,3 +35,10 @@ class AuthMeViewTests(APITestCase):
     def test_patch_me_rejects_empty_payload(self):
         response = self.client.patch('/api/v1/auth/me/', {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_organization_removes_current_organization(self):
+        response = self.client.delete('/api/v1/auth/delete-organization/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Organization.objects.filter(id=self.organization.id).exists())
+        self.assertFalse(User.objects.filter(id=self.user.id).exists())

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -55,3 +55,11 @@ class AuthViewSet(viewsets.GenericViewSet):
 
         serializer = UserSerializer(request.user)
         return Response(serializer.data)
+
+    @action(detail=False, methods=['delete'], permission_classes=[IsAuthenticated], url_path='delete-organization')
+    def delete_organization(self, request):
+        request.user.organization.delete()
+        return Response(
+            {'message': 'Organization successfully deleted.'},
+            status=status.HTTP_200_OK,
+        )

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -152,8 +152,8 @@
                         <div class="glass-card p-4 border border-danger-subtle">
                             <div class="section-title text-danger"><i class="bi bi-exclamation-triangle me-2"></i>Danger Zone</div>
                             <p class="text-muted mb-3">These actions are irreversible.</p>
-                            <button class="btn btn-outline-danger btn-sm me-2">Delete All Leads</button>
-                            <button class="btn btn-outline-danger btn-sm">Delete Organization</button>
+                            <button class="btn btn-outline-danger btn-sm me-2" id="delete-leads-btn">Delete All Leads</button>
+                            <button class="btn btn-outline-danger btn-sm" id="delete-org-btn">Delete Organization</button>
                         </div>
                     </div>
                 </div>
@@ -163,7 +163,7 @@
 
     <script type="module" src="/main.js"></script>
     <script type="module">
-        import { fetchWithAuth } from '/api.js';
+        import { fetchWithAuth, clearTokens } from '/api.js';
 
         const apiBaseUrl = (localStorage.getItem('api_base_url') || '').replace(/\/$/, '');
         const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
@@ -227,6 +227,73 @@
                     } finally {
                         saveBtn.disabled = false;
                         saveBtn.textContent = 'Save Changes';
+                    }
+                });
+            }
+
+            const deleteLeadsBtn = document.getElementById('delete-leads-btn');
+            if (deleteLeadsBtn) {
+                deleteLeadsBtn.addEventListener('click', async () => {
+                    if (!confirm('Delete every lead in this organization? This cannot be undone.')) {
+                        return;
+                    }
+
+                    deleteLeadsBtn.disabled = true;
+                    deleteLeadsBtn.textContent = 'Deleting...';
+
+                    try {
+                        const res = await fetchWithAuth('/leads/delete-all/', { method: 'DELETE' });
+                        const data = await res.json().catch(() => ({}));
+                        if (!res.ok) {
+                            alert(data.detail || data.error || 'Could not delete leads right now.');
+                            return;
+                        }
+
+                        alert(data.message || 'All leads were deleted.');
+                    } catch (e) {
+                        alert('Could not delete leads right now.');
+                    } finally {
+                        deleteLeadsBtn.disabled = false;
+                        deleteLeadsBtn.textContent = 'Delete All Leads';
+                    }
+                });
+            }
+
+            const deleteOrgBtn = document.getElementById('delete-org-btn');
+            if (deleteOrgBtn) {
+                deleteOrgBtn.addEventListener('click', async () => {
+                    const orgName = document.getElementById('org-name').value.trim();
+                    const typedName = prompt(`Type "${orgName}" to permanently delete this organization.`);
+                    if (typedName === null) {
+                        return;
+                    }
+                    if (!orgName || typedName.trim() !== orgName) {
+                        alert('Organization name did not match. Nothing was deleted.');
+                        return;
+                    }
+                    if (!confirm('This will permanently delete the organization and sign you out. Continue?')) {
+                        return;
+                    }
+
+                    deleteOrgBtn.disabled = true;
+                    deleteOrgBtn.textContent = 'Deleting...';
+
+                    try {
+                        const res = await fetchWithAuth('/auth/delete-organization/', { method: 'DELETE' });
+                        const data = await res.json().catch(() => ({}));
+                        if (!res.ok) {
+                            alert(data.detail || data.error || 'Could not delete organization right now.');
+                            return;
+                        }
+
+                        clearTokens();
+                        alert(data.message || 'Organization deleted. You have been signed out.');
+                        window.location.href = '/login.html';
+                    } catch (e) {
+                        alert('Could not delete organization right now.');
+                    } finally {
+                        deleteOrgBtn.disabled = false;
+                        deleteOrgBtn.textContent = 'Delete Organization';
                     }
                 });
             }


### PR DESCRIPTION
## Summary
- add a scoped `DELETE /api/v1/leads/delete-all/` action for removing the current organization's leads
- add a `DELETE /api/v1/auth/delete-organization/` action for deleting the current organization
- wire the Settings danger zone buttons with confirmation prompts, disabled states, API calls, token clearing, and logout redirect
- cover tenant-scoped lead deletion and organization cascade deletion with API tests

## Validation
- `python3 -m py_compile backend/leads/views.py backend/users/views.py backend/leads/tests.py backend/users/tests.py`
- `node --check /tmp/leadorbit-settings-inline.mjs`
- `python manage.py test` from `backend/` via `uv run --with-requirements ../requirements.txt` (29 passed)
- `git diff --check`

Closes #24
