### PR TITLE
Fix #70: Use CELERY_RESULT_BACKEND env var instead of CELERY_BROKER_URL

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -141,7 +141,7 @@ REST_FRAMEWORK = {
 
 # Celery Configuration
 CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
-CELERY_RESULT_BACKEND = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/1')
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 # In local/dev, execute tasks in-process so lead imports/campaign runs work without a worker.


### PR DESCRIPTION
## Fixes #70

### Bug
In \ackend/backend/settings.py:144\, \CELERY_RESULT_BACKEND\ was reading from \os.getenv('CELERY_BROKER_URL')\ instead of \os.getenv('CELERY_RESULT_BACKEND')\. This meant the broker URL was being reused for the result backend, causing incorrect configuration.

### Changes
- Changed \CELERY_RESULT_BACKEND\ to read from \os.getenv('CELERY_RESULT_BACKEND')\ with default \'redis://localhost:6379/1'\
- Broker URL uses database 0, result backend now correctly uses database 1

### Impact
- Celery task results are now stored against the correct environment variable
- Proper separation between broker and result backend configurations