### PR TITLE
Require authentication for AI generation endpoint

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1010,6 +1010,18 @@ class CampaignWorkflowTests(APITestCase):
         self.assertTrue(response.data.get('fallback'))
         self.assertIn('SUBJECT:', response.data.get('generated', ''))
 
+    @override_settings(GEMINI_API_KEY='')
+    def test_ai_generate_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+
+        response = self.client.post(
+            '/api/v1/campaigns/ai-generate/',
+            {'prompt': 'Write an outreach email'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
     def test_dashboard_analytics_isolates_data_by_tenant(self):
         org2 = Organization.objects.create(name='Other Corp')
         other_user = User.objects.create_user(

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -355,7 +355,7 @@ class AIGenerateView(APIView):
     POST /api/v1/campaigns/ai-generate/
     Generate email content using the configured LLM provider for the campaign builder.
     """
-    permission_classes = [AllowAny]
+    permission_classes = [IsAuthenticated]
 
     def post(self, request, *args, **kwargs):
         prompt = (request.data.get('prompt') or '').strip()


### PR DESCRIPTION
## Linked Issue
Closes #85

## GSSoC
- gssoc:approved
- level:beginner
- type:security

## Summary
- Changed AIGenerateView from AllowAny to IsAuthenticated.
- Added a regression test covering anonymous access returning 401.
- Kept authenticated fallback generation behavior intact.

## Validation
- python -m py_compile campaigns/views.py campaigns/tests.py
- Attempted: python manage.py test campaigns.tests.CampaignWorkflowTests.test_ai_generate_requires_authentication campaigns.tests.CampaignWorkflowTests.test_ai_generate_returns_fallback_when_key_missing
- Blocked locally: Django is not installed in this environment.