### PR TITLE
Log email webhook processing errors

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1022,6 +1022,20 @@ class CampaignWorkflowTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_email_webhook_logs_processing_errors(self):
+        with patch('campaigns.views.CampaignLead.objects.filter', side_effect=RuntimeError('boom')):
+            with self.assertLogs('campaigns.views', level='ERROR') as logs:
+                response = self.client.post(
+                    '/api/v1/webhooks/email/',
+                    {'event': 'open', 'email': 'lead@acme.test'},
+                    format='json',
+                )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(
+            any('Webhook processing error for event=open email=lead@acme.test' in entry for entry in logs.output)
+        )
+
     def test_dashboard_analytics_isolates_data_by_tenant(self):
         org2 = Organization.objects.create(name='Other Corp')
         other_user = User.objects.create_user(

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -7,6 +9,8 @@ from leads.models import Lead
 
 from .models import Campaign, CampaignLead, SequenceStep
 from .serializers import CampaignSerializer, SequenceStepSerializer
+
+logger = logging.getLogger(__name__)
 
 class CampaignViewSet(viewsets.ModelViewSet):
     serializer_class = CampaignSerializer
@@ -209,7 +213,12 @@ class WebhookView(APIView):
                         if cl.current_step and cl.current_step.channel_type == 'CONDITION_CLICK':
                             _execute_condition_click_step(cl, cl.current_step, now=now)
             except Exception as e:
-                pass
+                logger.exception(
+                    'Webhook processing error for event=%s email=%s: %s',
+                    event_type,
+                    lead_email,
+                    e,
+                )
                 
         return Response({"status": "received"}, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Linked Issue
Closes #86

## GSSoC
- gssoc:approved
- level:beginner
- type:bug

## Summary
- Added a module logger for campaign views.
- Replaced the bare webhook exception swallow with logger.exception including event and email context.
- Added a regression test that verifies webhook processing errors are logged while preserving the received response.

## Validation
- python -m py_compile campaigns/views.py campaigns/tests.py
- Full Django test command blocked locally because Django is not installed in this environment.