### PR TITLE
Reject duplicate registration emails

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -20,6 +20,11 @@ class RegisterSerializer(serializers.Serializer):
     first_name = serializers.CharField(required=False)
     last_name = serializers.CharField(required=False)
 
+    def validate_email(self, value):
+        if User.objects.filter(email__iexact=value).exists():
+            raise serializers.ValidationError('A user with this email already exists.')
+        return value
+
     def create(self, validated_data):
         org = Organization.objects.create(name=validated_data['organization_name'])
         user = User.objects.create_user(

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -5,6 +5,30 @@ from tenants.models import Organization
 from users.models import User
 
 
+class RegisterViewTests(APITestCase):
+    def test_register_rejects_duplicate_email_case_insensitive(self):
+        organization = Organization.objects.create(name='Existing Org')
+        User.objects.create_user(
+            email='Admin@Example.com',
+            password='StrongPass123!',
+            organization=organization,
+            role='ADMIN',
+        )
+
+        response = self.client.post(
+            '/api/v1/auth/register/',
+            {
+                'email': 'admin@example.com',
+                'password': 'StrongPass123!',
+                'organization_name': 'New Org',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('email', response.data)
+
+
 class AuthMeViewTests(APITestCase):
     def setUp(self):
         self.organization = Organization.objects.create(name='Org Before')


### PR DESCRIPTION
Closes #87

GSSoC labels: `gssoc:approved`, `level:beginner`

## Summary
- Added case-insensitive duplicate email validation to `RegisterSerializer`.
- Return a clean `400 Bad Request` with an `email` validation error before creating a new organization/user.
- Added a focused register API test for duplicate emails with different casing.

## Validation
- `python -m py_compile users\serializers.py users\tests.py`
- Full Django test command is blocked locally because Django is not installed in this environment (`ModuleNotFoundError: No module named 'django'`).