### PR TITLE
Require confirmation before unsubscribe

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1056,7 +1056,7 @@ class CampaignWorkflowTests(APITestCase):
         response = self.client.get('/api/v1/analytics/dashboard/')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_unsubscribe_view_marks_lead_unsubscribed(self):
+    def test_unsubscribe_get_shows_confirmation_without_updating_lead(self):
         lead = Lead.objects.create(
             organization=self.organization,
             email='unsubscribe@acme.test',
@@ -1064,6 +1064,21 @@ class CampaignWorkflowTests(APITestCase):
         token = generate_unsubscribe_token(lead.id)
 
         response = self.client.get(f'/api/v1/unsubscribe/{lead.id}/{token}/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('Confirm unsubscribe', response.content.decode('utf-8'))
+        self.assertIn('method="post"', response.content.decode('utf-8'))
+
+        lead.refresh_from_db()
+        self.assertFalse(lead.global_unsubscribe)
+
+    def test_unsubscribe_post_marks_lead_unsubscribed(self):
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='unsubscribe@acme.test',
+        )
+        token = generate_unsubscribe_token(lead.id)
+
+        response = self.client.post(f'/api/v1/unsubscribe/{lead.id}/{token}/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('You have been unsubscribed', response.content.decode('utf-8'))
 

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -425,9 +425,29 @@ class AIGenerateView(APIView):
         return f"SUBJECT: {subject}\nBODY: {body}"
     
 from django.http import HttpResponse
-from pathlib import Path
+from django.middleware.csrf import get_token
 from leads.models import Lead
 from .utils import verify_unsubscribe_token
+
+
+def _unsubscribe_page(title, message, extra_html=''):
+    return (
+        '<!DOCTYPE html>'
+        '<html lang="en">'
+        '<head>'
+        '<meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f'<title>{title} | LeadOrbit</title>'
+        '<style>body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,sans-serif;background:#f8fafc;color:#111827;}'
+        '.container{max-width:720px;margin:72px auto;padding:32px;background:#ffffff;border:1px solid #e5e7eb;border-radius:24px;box-shadow:0 20px 80px rgba(15,23,42,.08);}'
+        'h1{margin-top:0;font-size:2rem;color:#0f172a;}p{font-size:1rem;line-height:1.7;color:#475569;}'
+        'button{margin-top:12px;border:0;border-radius:999px;background:#1d4ed8;color:#fff;font-weight:700;padding:12px 20px;cursor:pointer;}'
+        '</style>'
+        '</head>'
+        f'<body><div class="container"><h1>{title}</h1><p>{message}</p>{extra_html}</div></body>'
+        '</html>'
+    )
+
 
 def unsubscribe_view(request, lead_id, token):
     """Public unsubscribe endpoint for GDPR/CAN-SPAM compliance."""
@@ -447,29 +467,28 @@ def unsubscribe_view(request, lead_id, token):
             status=404,
         )
 
+    if request.method != 'POST':
+        csrf_token = get_token(request)
+        form = (
+            f'<form method="post" action="{request.path}">'
+            f'<input type="hidden" name="csrfmiddlewaretoken" value="{csrf_token}">'
+            '<button type="submit">Confirm unsubscribe</button>'
+            '</form>'
+        )
+        html = _unsubscribe_page(
+            'Confirm unsubscribe',
+            'Please confirm that you want to unsubscribe from future emails sent through LeadOrbit.',
+            form,
+        )
+        return HttpResponse(html, content_type='text/html')
+
     lead.global_unsubscribe = True
     lead.save(update_fields=["global_unsubscribe"])
 
-    confirmation_path = Path(__file__).resolve().parents[2] / 'frontend' / 'unsubscribe.html'
-    if confirmation_path.exists():
-        html = confirmation_path.read_text(encoding='utf-8')
-    else:
-        html = (
-            '<!DOCTYPE html>'
-            '<html lang="en">'
-            '<head>'
-            '<meta charset="utf-8">'
-            '<meta name="viewport" content="width=device-width,initial-scale=1">'
-            '<title>Unsubscribed | LeadOrbit</title>'
-            '<style>body{margin:0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Ubuntu,sans-serif;background:#f8fafc;color:#111827;}'
-            '.container{max-width:720px;margin:72px auto;padding:32px;background:#ffffff;border:1px solid #e5e7eb;border-radius:24px;box-shadow:0 20px 80px rgba(15,23,42,.08);}'
-            'h1{margin-top:0;font-size:2rem;color:#0f172a;}p{font-size:1rem;line-height:1.7;color:#475569;}a{color:#2563eb;text-decoration:none;}</style>'
-            '</head>'
-            '<body><div class="container"><h1>Unsubscribed</h1>'
-            '<p>You have been unsubscribed from all future emails sent through LeadOrbit.</p>'
-            '<p>If you received this link by mistake, no further action is needed.</p>'
-            '</div></body>'
-            '</html>'
-        )
+    html = _unsubscribe_page(
+        'Unsubscribed',
+        'You have been unsubscribed from all future emails sent through LeadOrbit.',
+        '<p>If you received this link by mistake, no further action is needed.</p>',
+    )
 
     return HttpResponse(html, content_type='text/html')


### PR DESCRIPTION
Closes #88

GSSoC labels: `gssoc:approved`, `level:beginner`

## Summary
- Changed unsubscribe GET requests to show a confirmation page only.
- Moved the state-changing unsubscribe update to POST with a CSRF token included in the confirmation form.
- Added focused tests for the non-mutating GET flow and POST unsubscribe behavior.

## Validation
- `python -m py_compile campaigns\views.py campaigns\tests.py`
- Full Django test command is blocked locally because Django is not installed in this environment (`ModuleNotFoundError: No module named 'django'`).