### PR TITLE
Add campaign pause and resume controls

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -942,6 +942,63 @@ class CampaignWorkflowTests(APITestCase):
         response = self.client.post(f'/api/v1/campaigns/{campaign.id}/launch/', {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_pause_action_pauses_active_campaign(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Pause active campaign',
+            status='ACTIVE',
+        )
+
+        response = self.client.post(f'/api/v1/campaigns/{campaign.id}/pause/', {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        campaign.refresh_from_db()
+        self.assertEqual(campaign.status, 'PAUSED')
+        self.assertEqual(response.data['status'], 'PAUSED')
+
+    def test_pause_rejects_non_active_campaign(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Pause draft campaign',
+            status='DRAFT',
+        )
+
+        response = self.client.post(f'/api/v1/campaigns/{campaign.id}/pause/', {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        campaign.refresh_from_db()
+        self.assertEqual(campaign.status, 'DRAFT')
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_resume_action_activates_paused_campaign_and_triggers_processing(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Resume paused campaign',
+            status='PAUSED',
+        )
+
+        with patch('campaigns.tasks.process_active_leads.delay') as mocked_delay:
+            response = self.client.post(f'/api/v1/campaigns/{campaign.id}/resume/', {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        campaign.refresh_from_db()
+        self.assertEqual(campaign.status, 'ACTIVE')
+        self.assertEqual(response.data['status'], 'ACTIVE')
+        mocked_delay.assert_called_once()
+
+    def test_resume_rejects_non_paused_campaign(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Resume active campaign',
+            status='ACTIVE',
+        )
+
+        response = self.client.post(f'/api/v1/campaigns/{campaign.id}/resume/', {}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        campaign.refresh_from_db()
+        self.assertEqual(campaign.status, 'ACTIVE')
+
     def test_condition_time_is_mapped_to_delay_minutes(self):
         payload = {
             'name': 'Condition delay mapping',

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -133,6 +133,61 @@ class CampaignViewSet(viewsets.ModelViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @action(detail=True, methods=['post'])
+    def pause(self, request, pk=None):
+        campaign = self.get_object()
+
+        if campaign.status != 'ACTIVE':
+            return Response(
+                {
+                    "error": "Only active campaigns can be paused.",
+                    "campaign_id": str(campaign.id),
+                    "status": campaign.status,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        campaign.status = 'PAUSED'
+        campaign.save(update_fields=['status'])
+
+        return Response(
+            {
+                "message": "Campaign paused.",
+                "campaign_id": str(campaign.id),
+                "status": campaign.status,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @action(detail=True, methods=['post'])
+    def resume(self, request, pk=None):
+        from .tasks import process_active_leads
+
+        campaign = self.get_object()
+
+        if campaign.status != 'PAUSED':
+            return Response(
+                {
+                    "error": "Only paused campaigns can be resumed.",
+                    "campaign_id": str(campaign.id),
+                    "status": campaign.status,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        campaign.status = 'ACTIVE'
+        campaign.save(update_fields=['status'])
+        process_active_leads.delay()
+
+        return Response(
+            {
+                "message": "Campaign resumed. Processing queue triggered.",
+                "campaign_id": str(campaign.id),
+                "status": campaign.status,
+            },
+            status=status.HTTP_200_OK,
+        )
+
 class SequenceStepViewSet(viewsets.ModelViewSet):
     serializer_class = SequenceStepSerializer
     queryset = SequenceStep.objects.all()

--- a/frontend/campaigns.html
+++ b/frontend/campaigns.html
@@ -272,9 +272,18 @@
                     ? previewSteps.map(label => `<span class="step-chip"><i class="bi bi-dot"></i>${escapeHtml(label)}</span>`).join('')
                     : '<span class="text-muted small">No sequence steps configured</span>';
 
-                const toggleTarget = status === 'ACTIVE' ? 'PAUSED' : 'ACTIVE';
-                const toggleLabel = status === 'ACTIVE' ? 'Pause' : 'Activate';
-                const toggleIcon = status === 'ACTIVE' ? 'bi-pause-circle' : 'bi-play-circle';
+                const actionDetails = {
+                    ACTIVE: { endpoint: 'pause', nextStatus: 'PAUSED', label: 'Pause', icon: 'bi-pause-circle' },
+                    PAUSED: { endpoint: 'resume', nextStatus: 'ACTIVE', label: 'Resume', icon: 'bi-play-circle' },
+                    DRAFT: { endpoint: 'launch', nextStatus: 'ACTIVE', label: 'Launch', icon: 'bi-rocket-takeoff' },
+                }[status];
+                const actionButton = actionDetails ? `
+                                    <button class="btn btn-sm btn-outline-success"
+                                        data-action-id="${campaign.id}"
+                                        data-action-endpoint="${actionDetails.endpoint}"
+                                        data-next-status="${actionDetails.nextStatus}">
+                                        <i class="bi ${actionDetails.icon} me-1"></i>${actionDetails.label}
+                                    </button>` : '';
 
                 return `
                     <div class="col-12 col-md-6 col-xl-4">
@@ -310,31 +319,26 @@
                                     <a href="/campaign-builder.html?id=${campaign.id}" class="btn btn-sm btn-outline-primary flex-grow-1">
                                         <i class="bi bi-pencil me-1"></i> Edit
                                     </a>
-                                    <button class="btn btn-sm btn-outline-success"
-                                        data-toggle-id="${campaign.id}"
-                                        data-current-status="${status}"
-                                        data-toggle-target="${toggleTarget}">
-                                        <i class="bi ${toggleIcon} me-1"></i>${toggleLabel}
-                                    </button>
+                                    ${actionButton}
                                 </div>
                             </div>
                         </div>
                     </div>`;
             }).join('');
 
-            grid.querySelectorAll('[data-toggle-id]').forEach(button => {
+            grid.querySelectorAll('[data-action-id]').forEach(button => {
                 button.addEventListener('click', async () => {
-                    const campaignId = button.dataset.toggleId;
-                    const nextStatus = button.dataset.toggleTarget;
+                    const campaignId = button.dataset.actionId;
+                    const endpoint = button.dataset.actionEndpoint;
+                    const nextStatus = button.dataset.nextStatus;
                     const originalLabel = button.innerHTML;
 
                     button.disabled = true;
                     button.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Updating';
 
                     try {
-                        const res = await fetchWithAuth(`/campaigns/${campaignId}/`, {
-                            method: 'PATCH',
-                            body: JSON.stringify({ status: nextStatus }),
+                        const res = await fetchWithAuth(`/campaigns/${campaignId}/${endpoint}/`, {
+                            method: 'POST',
                         });
 
                         if (!res.ok) {


### PR DESCRIPTION
Closes #89

## GSSoC
- Label: `gssoc:approved`
- Level: `level:intermediate`

## Summary
- Adds dedicated `pause` and `resume` actions to `CampaignViewSet`.
- Validates state transitions so only active campaigns pause and only paused campaigns resume.
- Triggers campaign processing after resume.
- Updates the campaigns UI to call `launch`, `pause`, and `resume` action endpoints based on current campaign status.
- Adds focused backend tests for valid and invalid pause/resume transitions.

## Validation
- `python -m py_compile campaigns\views.py campaigns\tests.py`
- `Select-String -Path frontend\campaigns.html -Pattern 'data-action-endpoint|/pause/|/resume/|launch'`

## Note
- Targeted Django tests could not run locally because Django is not installed in the current Python environment (`ModuleNotFoundError: No module named 'django'`).