### PR TITLE
Fix settings dark mode toggle timing

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -104,7 +104,14 @@ if (document.readyState === 'loading') {
     setActiveNavLink();
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
+let appShellInitialized = false;
+
+async function initAppShell() {
+    if (appShellInitialized) {
+        return;
+    }
+    appShellInitialized = true;
+
     initThemeToggle();
     initPasswordVisibilityToggle();
 
@@ -173,7 +180,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             overlay.classList.remove('active');
         });
     }
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAppShell, { once: true });
+} else {
+    initAppShell();
+}
 
 // ==========================================
 // KEYBOARD SHORTCUTS IMPLEMENTATION (#67)
@@ -326,4 +339,3 @@ if (document.readyState === 'loading') {
 } else {
     initKeyboardShortcuts();
 }
-


### PR DESCRIPTION
## Summary
- Fix the Workspace Settings dark mode toggle initialization so it works even when `frontend/main.js` executes after `DOMContentLoaded`.
- Keep the shared app shell setup idempotent to avoid duplicate listeners while preserving the existing theme persistence flow.

Closes #129

## Verification
- `git diff --check`
- Served `frontend/` with `python3 -m http.server 4173`
- Browser verified `/settings.html`:
  - toggle from light to dark updates `data-theme`, `data-bs-theme`, `colorScheme`, and checked state
  - reload preserves dark mode and checked state
  - toggle back to light updates the same state
  - reload preserves light mode and unchecked state

Note: local browser console also reports expected backend API connection errors because only the static frontend server was running for this UI check.
