### PR TITLE
feat: replace confirm() and prompt() with Bootstrap modals

### DIFF
--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -175,6 +175,76 @@
 
         const apiBaseUrl = (localStorage.getItem('api_base_url') || '').replace(/\/$/, '');
         const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+        // Bootstrap Modal Helpers
+function showConfirmModal(title, message, confirmLabel, onConfirm) {
+    const modalHtml = `
+        <div class="modal fade" id="dynamicConfirmModal" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">${title}</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>${message}</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-danger" id="dynamicConfirmBtn">${confirmLabel}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+    
+    const existingModal = document.getElementById('dynamicConfirmModal');
+    if (existingModal) existingModal.remove();
+    
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    const modal = new bootstrap.Modal(document.getElementById('dynamicConfirmModal'));
+    
+    document.getElementById('dynamicConfirmBtn').onclick = () => {
+        modal.hide();
+        if (onConfirm) onConfirm();
+    };
+    modal.show();
+}
+
+function showPromptModal(title, message, placeholder, onConfirm) {
+    const modalHtml = `
+        <div class="modal fade" id="dynamicPromptModal" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">${title}</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>${message}</p>
+                        <input type="text" class="form-control" id="dynamicPromptInput" placeholder="${placeholder}">
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-danger" id="dynamicPromptConfirmBtn">Confirm</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+    
+    const existingModal = document.getElementById('dynamicPromptModal');
+    if (existingModal) existingModal.remove();
+    
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    const modal = new bootstrap.Modal(document.getElementById('dynamicPromptModal'));
+    
+    document.getElementById('dynamicPromptConfirmBtn').onclick = () => {
+        const inputValue = document.getElementById('dynamicPromptInput').value;
+        modal.hide();
+        if (onConfirm) onConfirm(inputValue);
+    };
+    modal.show();
+}
         const defaultOAuthHost = isLocalhost ? 'http://127.0.0.1:8000' : 'https://leadorbit.onrender.com';
         const oauthHost = apiBaseUrl ? apiBaseUrl.replace(/\/api\/v1$/, '') : defaultOAuthHost;
 
@@ -274,9 +344,29 @@
             const deleteLeadsBtn = document.getElementById('delete-leads-btn');
             if (deleteLeadsBtn) {
                 deleteLeadsBtn.addEventListener('click', async () => {
-                    if (!confirm('Delete every lead in this organization? This cannot be undone.')) {
-                        return;
-                    }
+                    showConfirmModal('Delete All Leads', 'Delete every lead in this organization? This cannot be undone.', 'Yes, Delete', () => {
+    // Proceed with deletion
+    deleteLeadsBtn.disabled = true;
+    deleteLeadsBtn.textContent = 'Deleting...';
+    
+    (async () => {
+        try {
+            const res = await fetchWithAuth('/leads/delete-all/', { method: 'DELETE' });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                alert(data.detail || data.error || 'Could not delete leads right now.');
+                return;
+            }
+            alert(data.message || 'All leads were deleted.');
+        } catch (e) {
+            alert('Could not delete leads right now.');
+        } finally {
+            deleteLeadsBtn.disabled = false;
+            deleteLeadsBtn.textContent = 'Delete All Leads';
+        }
+    })();
+});
+return;
 
                     deleteLeadsBtn.disabled = true;
                     deleteLeadsBtn.textContent = 'Deleting...';
@@ -303,18 +393,38 @@
             if (deleteOrgBtn) {
                 deleteOrgBtn.addEventListener('click', async () => {
                     const orgName = document.getElementById('org-name').value.trim();
-                    const typedName = prompt(`Type "${orgName}" to permanently delete this organization.`);
-                    if (typedName === null) {
-                        return;
-                    }
-                    if (!orgName || typedName.trim() !== orgName) {
-                        alert('Organization name did not match. Nothing was deleted.');
-                        return;
-                    }
-                    if (!confirm('This will permanently delete the organization and sign you out. Continue?')) {
-                        return;
-                    }
-
+                    showPromptModal('Delete Organization', `Type "${orgName}" to permanently delete this organization.`, `Enter "${orgName}"`, (typedName) => {
+    if (!typedName) return;
+    if (typedName.trim() !== orgName) {
+        alert('Organization name did not match. Nothing was deleted.');
+        return;
+    }
+    
+    showConfirmModal('Confirm Deletion', 'This will permanently delete the organization and sign you out. Continue?', 'Yes, Delete', () => {
+        deleteOrgBtn.disabled = true;
+        deleteOrgBtn.textContent = 'Deleting...';
+        
+        (async () => {
+            try {
+                const res = await fetchWithAuth('/auth/delete-organization/', { method: 'DELETE' });
+                const data = await res.json().catch(() => ({}));
+                if (!res.ok) {
+                    alert(data.detail || data.error || 'Could not delete organization right now.');
+                    return;
+                }
+                clearTokens();
+                alert(data.message || 'Organization deleted. You have been signed out.');
+                window.location.href = '/login.html';
+            } catch (e) {
+                alert('Could not delete organization right now.');
+            } finally {
+                deleteOrgBtn.disabled = false;
+                deleteOrgBtn.textContent = 'Delete Organization';
+            }
+        })();
+    });
+});
+return;
                     deleteOrgBtn.disabled = true;
                     deleteOrgBtn.textContent = 'Deleting...';
 


### PR DESCRIPTION
Closes #59

## Changes Made
- Added `showConfirmModal()` and `showPromptModal()` helper functions
- Replaced native `confirm()` in delete leads flow
- Replaced native `prompt()` and `confirm()` in delete organization flow
- Used Bootstrap 5 modals with proper styling

## Files Modified
- `frontend/settings.html`