### PR TITLE
feat: add breadcrumb navigation to all authenticated pages

### DIFF
--- a/frontend/analytics.html
+++ b/frontend/analytics.html
@@ -81,7 +81,13 @@
                     </div>
                 </div>
             </header>
-
+     <!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb" class="container mt-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/dashboard.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Analytics</li>
+    </ol>
+</nav>
             <section class="content-wrap">
                 <div class="kpi-grid mb-4">
                     <div class="kpi-card">

--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -875,7 +875,14 @@
         }
     </style>
 </head>
-
+<!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb" class="container mt-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/dashboard.html">Home</a></li>
+        <li class="breadcrumb-item"><a href="/campaigns.html">Campaigns</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Builder</li>
+    </ol>
+</nav>
 <body class="builder-page">
     <!-- â”€â”€â”€ Top Bar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ -->
     <div class="top-bar">

--- a/frontend/campaigns.html
+++ b/frontend/campaigns.html
@@ -75,7 +75,13 @@
                     </div>
                 </div>
             </header>
-
+            <!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb" class="container mt-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/dashboard.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Campaigns</li>
+    </ol>
+</nav>
             <section class="content-wrap">
                 <div class="overview-grid">
                     <div class="overview-card">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -69,7 +69,12 @@
                     </div>
                 </div>
             </header>
-
+            <!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb" class="container mt-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">Dashboard</li>
+    </ol>
+</nav>
             <section class="content-wrap">
                 <div class="kpi-grid mb-4">
                     <div class="kpi-card">

--- a/frontend/leads.html
+++ b/frontend/leads.html
@@ -75,7 +75,13 @@
                     </div>
                 </div>
             </header>
-
+           <!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb" class="container mt-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/dashboard.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Leads</li>
+    </ol>
+</nav>
             <section class="content-wrap">
                 <div class="kpi-grid mb-4">
                     <div class="kpi-card">

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -64,7 +64,13 @@
                     <button id="logout-btn" class="btn btn-sm btn-logout">Logout</button>
                 </div>
             </header>
-
+      <!-- Breadcrumb Navigation -->
+<nav aria-label="breadcrumb" class="container mt-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/dashboard.html">Home</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Settings</li>
+    </ol>
+</nav>
             <section class="content-wrap">
                 <div class="row g-4">
                     <div class="col-lg-6">


### PR DESCRIPTION
Closes #58

## Changes Made
- Added breadcrumb navigation below `.top-header` on all authenticated pages
- Used Bootstrap 5 breadcrumb component
- Current page shown as non-clickable active item

## Pages Updated
- `frontend/dashboard.html`
- `frontend/leads.html`
- `frontend/campaigns.html`
- `frontend/campaign-builder.html`
- `frontend/analytics.html`
- `frontend/settings.html`

## Breadcrumb Structure
| Page | Breadcrumb |
|------|------------|
| dashboard.html | Home (active) |
| leads.html | Home → Leads |
| campaigns.html | Home → Campaigns |
| campaign-builder.html | Home → Campaigns → Builder |
| analytics.html | Home → Analytics |
| settings.html | Home → Settings |