### PR TITLE
docs: add CODE_OF_CONDUCT.md with reference in README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,10 @@ This Code of Conduct applies within all project spaces and also applies when an 
 
 ## Reporting Guidelines
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers.
+
+## Reporting Guidelines
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer by (https://github.com/Kuldeeep18/LeadOrbit/discussions) or contacting **@Kuldeeep18** directly.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ This README is based on the current codebase, not the older planning documents i
 - [Current Caveats](#current-caveats)
 - [Integration Notes](#integration-notes)
 
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to abide by its terms.
+
+## Contributing
+
+... existing contributing content ...
+
 ## What Works Today
 
 - JWT auth with organization creation during signup


### PR DESCRIPTION
Closes #34

## Changes Made
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)
- Added contact information for reporting violations
- Updated `README.md` with link to Code of Conduct

## Files Modified
- `CODE_OF_CONDUCT.md` (new file)
- `README.md` (added reference)

## Checklist
- [x] CODE_OF_CONDUCT.md exists at repo root
- [x] Uses Contributor Covenant v2.1
- [x] Contact info is filled
- [x] README references the Code of Conduct