### PR TITLE
feat: add import leads CTA to campaign builder empty state

### DIFF
--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -1278,7 +1278,20 @@
                                     <th>Company</th>
                                 </tr>
                             </thead>
-                            <tbody>${rows || '<tr><td colspan="5" class="text-muted py-4 text-center">No leads found. Import leads first.</td></tr>'}</tbody>
+                            <tbody>
+${rows || `
+<tr>
+    <td colspan="5" class="text-muted py-5 text-center">
+        <p class="mb-3">No leads found in your organization.</p>
+        <a href="/leads.html" class="btn btn-primary btn-sm d-inline-flex align-items-center gap-2">
+            <i class="bi bi-upload"></i>
+            <span>Go to Import Leads</span>
+        </a>
+    </td>
+</tr>
+`}
+</tbody>
+                           
                         </table>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Added an "Import Leads" call-to-action button to the Campaign Builder lead selection empty state.

## Changes Made

* Replaced the plain "No leads found" message with a richer empty-state UI
* Added a Bootstrap-styled "Go to Import Leads" button
* Linked the button to `/leads.html`
* Improved onboarding flow by removing a dead-end experience

## Testing

* Verified empty state renders correctly when no leads exist
* Verified button is centered and styled correctly
* Verified clicking the button redirects to `/leads.html`

Fixes #156
