### PR TITLE
fix: improve password visibility toggle styling

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -100,17 +100,35 @@
                                         placeholder="name@example.com" required style="border-left: none !important;">
                                 </div>
                             </div>
-                            <div class="mb-4">
-                                <label for="floatingPassword"
-                                    class="form-label text-muted small fw-semibold">Password</label>
-                                <div class="password-toggle-wrapper">
-                                    <input type="password" class="form-control form-control-lg fs-6" id="floatingPassword" autocomplete="current-password"
-                                        placeholder="Password" required>
-                                    <button type="button" id="floatingPasswordToggle" class="password-toggle-btn" aria-label="Show password"  aria-controls="floatingPassword">👁</button>
-                                </div>
                             </div>
 
-                            <div class="d-grid mb-3">
+<div class="mb-4">
+    <label for="floatingPassword" class="form-label text-muted small fw-semibold">
+        Password
+    </label>
+
+    <div class="password-toggle-wrapper">
+        <input
+            type="password"
+            class="form-control form-control-lg fs-6 custom-input"
+            id="floatingPassword"
+            placeholder="Password"
+            required
+        >
+
+        <button
+            type="button"
+            id="floatingPasswordToggle"
+            class="password-toggle-btn"
+            aria-label="Show password"
+            aria-pressed="false"
+        >
+            <i class="bi bi-eye" aria-hidden="true"></i>
+        </button>
+    </div>
+</div>
+
+<div class="d-grid mb-3">
                                 <button class="btn btn-lg fw-semibold text-dark" style="background: linear-gradient(45deg, #00b4db, #00ffca); border: none;" type="submit">Sign In</button>
                             </div>
                         </form>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -37,25 +37,41 @@ function initThemeToggle() {
 }
 
 function initPasswordVisibilityToggle() {
-    const toggles = [
-        { inputId: 'floatingPassword', toggleId: 'floatingPasswordToggle' },
-        { inputId: 'password', toggleId: 'passwordToggle' }
-    ];
+  const toggles = [
+    { inputId: 'floatingPassword', toggleId: 'floatingPasswordToggle' },
+    { inputId: 'password', toggleId: 'passwordToggle' }
+  ];
 
-    toggles.forEach(({ inputId, toggleId }) => {
-        const input = document.getElementById(inputId);
-        const toggle = document.getElementById(toggleId);
-        if (!input || !toggle) {
-            return;
-        }
+  toggles.forEach(({ inputId, toggleId }) => {
+    const input = document.getElementById(inputId);
+    const toggle = document.getElementById(toggleId);
 
-        toggle.addEventListener('click', () => {
-            const show = input.type === 'password';
-            input.type = show ? 'text' : 'password';
-            toggle.textContent = show ? '🙈' : '👁';
-            toggle.setAttribute('aria-label', show ? 'Hide password' : 'Show password');
-        });
+    if (!input || !toggle) {
+      return;
+    }
+
+    const updateToggleState = () => {
+      const isPasswordVisible = input.type === 'text';
+
+      toggle.innerHTML = isPasswordVisible
+        ? '<i class="bi bi-eye-slash" aria-hidden="true"></i>'
+        : '<i class="bi bi-eye" aria-hidden="true"></i>';
+
+      toggle.setAttribute(
+        'aria-label',
+        isPasswordVisible ? 'Hide password' : 'Show password'
+      );
+
+      toggle.setAttribute('aria-pressed', String(isPasswordVisible));
+    };
+
+    updateToggleState();
+
+    toggle.addEventListener('click', () => {
+      input.type = input.type === 'password' ? 'text' : 'password';
+      updateToggleState();
     });
+  });
 }
 
 applyTheme(getTheme());

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -118,13 +118,31 @@
                                 </div>
                             </div>
                             <div class="mb-4">
-                                <label for="password" class="form-label text-muted small fw-semibold">Password</label>
-                                <div class="password-toggle-wrapper">
-                                    <input type="password" class="form-control form-control-lg fs-6" id="password" autocomplete="new-password"
-                                        placeholder="Min. 8 characters" required>
-                                    <button type="button" id="passwordToggle" class="password-toggle-btn" aria-label="Show password" aria-controls="password">👁</button>
-                                </div>
-                            </div>
+    <label for="password"
+        class="form-label text-muted small fw-semibold">
+        Password
+    </label>
+
+    <div class="password-toggle-wrapper">
+        <input
+            type="password"
+            class="form-control form-control-lg fs-6 custom-input"
+            id="password"
+            placeholder="Min. 8 characters"
+            required
+        >
+
+        <button
+            type="button"
+            id="passwordToggle"
+            class="password-toggle-btn"
+            aria-label="Show password"
+            aria-pressed="false"
+        >
+            <i class="bi bi-eye" aria-hidden="true"></i>
+        </button>
+    </div>
+</div>
 
                             <div class="d-grid mb-3">
                                 <button class="btn btn-lg fw-semibold text-dark" style="background: linear-gradient(45deg, #00b4db, #00ffca); border: none;" type="submit">Sign Up</button>

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -536,33 +536,6 @@ body.auth-page {
     color: var(--link-color) !important;
 }
 
-.password-toggle-wrapper {
-    position: relative;
-}
-
-.password-toggle-wrapper .form-control {
-    padding-right: 2.8rem;
-}
-
-.password-toggle-btn {
-    position: absolute;
-    top: 50%;
-    right: 0.75rem;
-    transform: translateY(-50%);
-    border: none;
-    background: transparent;
-    color: currentColor;
-    padding: 0;
-    margin: 0;
-    line-height: 1;
-    cursor: pointer;
-    font-size: 1.05rem;
-    width: 1.75rem;
-    height: 1.75rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-}
 
 .password-toggle-btn:focus-visible {
     outline: 2px solid rgba(13, 110, 253, 0.35);
@@ -1221,4 +1194,65 @@ body.auth-page {
     height: 40px;
     border-radius: 50%;
     flex-shrink: 0;
+}
+
+.password-toggle-wrapper {
+  position: relative;
+  display: block;
+}
+
+.password-toggle-wrapper .form-control {
+  padding-right: 3rem;
+  background-color: rgba(15, 23, 42, 0.55);
+  color: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.password-toggle-wrapper .form-control::placeholder {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.password-toggle-wrapper .form-control:focus {
+  background-color: rgba(15, 23, 42, 0.75);
+  color: #ffffff;
+  border-color: rgba(0, 180, 219, 0.65);
+  box-shadow: 0 0 0 0.2rem rgba(0, 180, 219, 0.15);
+}
+
+.password-toggle-btn {
+  position: absolute;
+  top: 50%;
+  right: 0.85rem;
+  transform: translateY(-50%);
+  z-index: 5;
+
+  width: 1.75rem;
+  height: 1.75rem;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  border: none;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.75);
+
+  padding: 0;
+  margin: 0;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.password-toggle-btn:hover {
+  color: #ffffff;
+}
+
+.password-toggle-btn:focus-visible {
+  outline: 2px solid rgba(0, 180, 219, 0.6);
+  outline-offset: 2px;
+  border-radius: 999px;
+}
+
+.password-toggle-btn i {
+  pointer-events: none;
 }


### PR DESCRIPTION
## Summary

This PR improves the password visibility toggle on both the login and register pages.

The password toggle behavior was partially working before, but the UI was inconsistent with the LeadOrbit authentication page design. The password field appeared as a white input while the rest of the form used the dark themed styling, and the visible-password state used an emoji-style icon. This PR keeps the existing show/hide password functionality while making the UI cleaner, consistent, and more accessible.

Closes Issue #126

## What Was Fixed

### Before

- Password visibility toggle was present, but the UI looked inconsistent.
- Password input appeared white while the email/name fields used the dark auth-page theme.
- Toggle icon used an emoji-style icon in the visible password state.
- Toggle button alignment and focus styling looked unpolished.
- Login and register password inputs did not visually match the rest of the form.

### After

- Password input now follows the same dark theme as the other auth inputs.
- Toggle uses Bootstrap Icons instead of emoji icons.
- Eye icon is shown when the password is hidden.
- Eye-slash icon is shown when the password is visible.
- Toggle button remains properly aligned inside the password input.
- Accessibility attributes are updated dynamically using `aria-label` and `aria-pressed`.
- Login and register pages now have consistent password toggle styling.

## Changes Made

### `frontend/main.js`

- Updated the password visibility toggle logic.
- Replaced emoji-based state indication with Bootstrap Icons:
  - `bi-eye` for hidden password state
  - `bi-eye-slash` for visible password state
- Added dynamic `aria-label` updates:
  - `Show password`
  - `Hide password`
- Added dynamic `aria-pressed` updates for better accessibility.
- Preserved existing password show/hide behavior.

### `frontend/login.html`

- Updated the login password field markup.
- Added consistent `custom-input` styling to the password input.
- Added initial Bootstrap eye icon inside the toggle button.
- Added initial accessibility attributes to the toggle button.

### `frontend/register.html`
- Updated the register password field markup.
 Added consistent `custom-input` styling to the password input.
- Added initial Bootstrap eye icon inside the toggle button.
- Added initial accessibility attributes to the toggle button.

### `frontend/theme.css`
- Improved password toggle wrapper styling.
- Ensured password input uses the dark auth-page theme.
- Added proper right padding so text does not overlap the toggle button.
- Improved toggle button positioning and alignment.
- Added hover styling for the toggle icon.
- Added `focus-visible` styling for keyboard accessibility.
- Ensured icon clicks are handled through the button using `pointer-events: none` on the icon.

## Testing Performed

Manually tested on both authentication pages:
- `login.html`
- `register.html`

Verified the following:
- Password is hidden by default.
- Eye icon appears inside the password input.
- Clicking the icon shows the password.
- Icon changes to eye-slash when password is visible.
- Clicking again hides the password.
- Icon changes back to eye when password is hidden.
- Password field styling matches the dark auth theme.
- Toggle button remains aligned inside the input.
- No emoji icon appears after the fix.
- No white password input remains after the fix.
- Login page UI remains intact.
- Register page UI remains intact.
- No browser console errors observed during manual testing.

## **Screenshots**

### **Before**

#### **Login page**

- Password input was white and used inconsistent toggle icon styling.
<img width="645" height="735" alt="Screenshot 2026-06-10 110405" src="https://github.com/user-attachments/assets/adcd5d61-56a5-4ad5-b7e4-36672c6004f7" />
<br></br>
<img width="638" height="714" alt="Screenshot 2026-06-10 110557" src="https://github.com/user-attachments/assets/c7cf3713-dbbe-4eb2-8fcb-1cbaec94e30d" />
<br></br>

- Toggle icon used emoji-style rendering.
<img width="638" height="714" alt="Screenshot 2026-06-10 110557" src="https://github.com/user-attachments/assets/9cd3f0c2-9b92-4554-b26a-960ee3bab97b" />
<br></br>

#### **Register page**
Password input was white and used inconsistent toggle icon styling.

`before-register-hidden screenshot`
<img width="762" height="790" alt="Screenshot 2026-06-10 110801" src="https://github.com/user-attachments/assets/073a27e8-6255-4dfb-81c6-e45c6d2a99ca" />
<br></br>

`before-register-visible screenshot`
<img width="679" height="663" alt="Screenshot 2026-06-10 110711" src="https://github.com/user-attachments/assets/cf8ca6b0-31fb-437a-8e77-f8f6a6eb9d09" />


### **After**

#### **Login page**
**Password input now matches the dark auth theme and uses Bootstrap Icons.**

`after-login-hidden screenshot`
<img width="684" height="733" alt="Screenshot 2026-06-10 115826" src="https://github.com/user-attachments/assets/22c1be8f-d2e9-4c60-a4d5-521737b90eae" />
<br></br>

`after-login-visible screenshot`
<img width="692" height="726" alt="Screenshot 2026-06-10 115757" src="https://github.com/user-attachments/assets/c8e2d5ee-c75b-4c64-b867-3459cb4f51bc" />

#### **Register page**
**Password input now matches the dark auth theme and uses Bootstrap Icons.**

`after-register-hidden screenshot`
<img width="762" height="819" alt="Screenshot 2026-06-10 115929" src="https://github.com/user-attachments/assets/4e3d334b-8eb8-4bc6-bb83-c849f58c96c8" />
<br></br>

`after-register-visible screenshot`
<img width="813" height="743" alt="Screenshot 2026-06-10 115921" src="https://github.com/user-attachments/assets/923d5bcc-6d81-4646-9f07-11e261eb41cb" />
