### PR TITLE
fix: calculate lead quality scores

### DIFF
--- a/backend/leads/models.py
+++ b/backend/leads/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from tenants.models import TenantModel
 import uuid
+from .scoring import calculate_lead_score
 
 class Lead(TenantModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -16,6 +17,12 @@ class Lead(TenantModel):
 
     class Meta:
         unique_together = ('organization', 'email')
+
+    def save(self, *args, **kwargs):
+        self.score = calculate_lead_score(self)
+        if kwargs.get('update_fields') is not None:
+            kwargs['update_fields'] = set(kwargs['update_fields']) | {'score'}
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return f"{self.first_name} {self.last_name} ({self.email})"

--- a/backend/leads/scoring.py
+++ b/backend/leads/scoring.py
@@ -1,0 +1,77 @@
+FREE_EMAIL_DOMAINS = {
+    "aol.com",
+    "gmail.com",
+    "hotmail.com",
+    "icloud.com",
+    "live.com",
+    "outlook.com",
+    "proton.me",
+    "protonmail.com",
+    "yahoo.com",
+}
+
+HIGH_INTENT_TITLE_KEYWORDS = {
+    "ceo",
+    "chief",
+    "co-founder",
+    "cofounder",
+    "director",
+    "founder",
+    "head",
+    "lead",
+    "manager",
+    "owner",
+    "vp",
+}
+
+
+def _clean(value):
+    return str(value or "").strip()
+
+
+def _email_domain(email):
+    email = _clean(email).lower()
+    if "@" not in email:
+        return ""
+    return email.rsplit("@", 1)[1]
+
+
+def _has_high_intent_title(custom_data):
+    if not isinstance(custom_data, dict):
+        return False
+
+    title = _clean(
+        custom_data.get("title")
+        or custom_data.get("job_title")
+        or custom_data.get("role")
+        or custom_data.get("position")
+    ).lower()
+    return any(keyword in title for keyword in HIGH_INTENT_TITLE_KEYWORDS)
+
+
+def calculate_lead_score(lead):
+    """Return a 0-100 fit score from lead completeness and buyer-fit signals."""
+    score = 0
+    email_domain = _email_domain(getattr(lead, "email", ""))
+
+    if email_domain:
+        score += 20
+        if email_domain not in FREE_EMAIL_DOMAINS:
+            score += 15
+
+    if _clean(getattr(lead, "first_name", "")):
+        score += 8
+    if _clean(getattr(lead, "last_name", "")):
+        score += 7
+    if _clean(getattr(lead, "company", "")):
+        score += 20
+    if _clean(getattr(lead, "linkedin_url", "")):
+        score += 15
+    if _clean(getattr(lead, "phone", "")):
+        score += 10
+
+    custom_data = getattr(lead, "custom_data", {}) or {}
+    if _has_high_intent_title(custom_data):
+        score += 5
+
+    return min(score, 100)

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -25,6 +25,26 @@ class LeadImportTests(APITestCase):
         self.assertEqual(lead.company, 'Acme')
         self.assertEqual(lead.linkedin_url, 'https://linkedin.com/in/alice')
         self.assertEqual(lead.phone, '+123456789')
+        self.assertGreater(lead.score, 0)
+
+    def test_scoring_ranks_complete_business_leads_above_sparse_free_email_leads(self):
+        sparse = Lead.objects.create(
+            organization=self.organization,
+            email='unknown@gmail.com',
+        )
+        complete = Lead.objects.create(
+            organization=self.organization,
+            email='alex@acme.com',
+            first_name='Alex',
+            last_name='Morgan',
+            company='Acme',
+            phone='+15551234567',
+            linkedin_url='https://linkedin.com/in/alex',
+            custom_data={'title': 'VP Sales'},
+        )
+
+        self.assertGreater(complete.score, sparse.score)
+        self.assertEqual(complete.score, 100)
 
 
 class LeadIsolationAPITests(APITestCase):
@@ -80,6 +100,7 @@ class LeadIsolationAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         created = Lead.objects.get(email='new-orgb-lead@example.com')
         self.assertEqual(created.organization_id, self.org_b.id)
+        self.assertGreater(response.data['score'], 0)
 
     def test_delete_all_removes_only_current_users_organization_leads(self):
         self.client.force_authenticate(self.user_a)


### PR DESCRIPTION
## Summary
- add deterministic lead quality scoring from completeness and buyer-fit signals
- recompute `Lead.score` automatically on create/update, including `update_fields` saves
- cover CSV import and API create paths so new leads no longer stay stuck at score `0`

## Root cause
`Lead.score` existed and was exposed in the UI/API, but the backend never calculated it. Because the serializer marks `score` read-only, imported and created leads were always ranked as `0`, making lead prioritization ineffective.

## Validation
- `/opt/homebrew/bin/python3.14 -m venv .venv && .venv/bin/pip install -r requirements.txt`
- `.venv/bin/python backend/manage.py test leads` -> 5 passed
- `cd backend && ../.venv/bin/python manage.py test` -> 42 passed
- `python3 -m py_compile backend/leads/models.py backend/leads/scoring.py backend/leads/tests.py`
- `git diff --check HEAD~1..HEAD`

Closes #133
