### PR TITLE
feat: add spintax email variations

### DIFF
--- a/backend/campaigns/spintax.py
+++ b/backend/campaigns/spintax.py
@@ -1,0 +1,28 @@
+import random
+import re
+
+SPINTAX_PATTERN = re.compile(r"\{([^{}]*\|[^{}]*)\}")
+
+
+def parse_spintax(text, chooser=None, max_passes=25):
+    """Resolve simple and nested spintax blocks such as {Hi|Hello}."""
+    if not text:
+        return text
+
+    chooser = chooser or random.choice
+    rendered = str(text)
+
+    for _ in range(max_passes):
+        match = SPINTAX_PATTERN.search(rendered)
+        if not match:
+            break
+
+        choices = match.group(1).split("|")
+        replacement = chooser(choices)
+        rendered = (
+            rendered[:match.start()]
+            + replacement
+            + rendered[match.end():]
+        )
+
+    return rendered

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -9,6 +9,7 @@ from .ai import personalize_email
 from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
 from .sms_service import send_sms, initiate_call
 from .models import CampaignLead, SequenceStep
+from .spintax import parse_spintax
 
 logger = logging.getLogger(__name__)
 
@@ -421,6 +422,8 @@ def send_email_step(campaign_lead_id, step_id):
             return
 
         subject, body = personalize_email(step.template_subject, step.template_body, clead.lead)
+        subject = parse_spintax(subject)
+        body = parse_spintax(body)
 
         account = clead.campaign.connected_account
         if account:

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from campaigns.models import Campaign, CampaignLead, ConnectedEmailAccount, SequenceStep
+from campaigns.spintax import parse_spintax
 from campaigns.tasks import (
     _get_campaign_steps,
     poll_gmail_for_replies,
@@ -447,6 +448,64 @@ class CampaignWorkflowTests(APITestCase):
         with patch('campaigns.tasks.send_email_step.delay') as mocked_delay:
             process_active_leads()
             mocked_delay.assert_called_once_with(campaign_lead.id, email_step.id)
+
+    def test_parse_spintax_resolves_nested_variants_with_custom_chooser(self):
+        rendered = parse_spintax(
+            '{Hi|Hello} {{firstName}}, {quick {idea|thought}|short note}',
+            chooser=lambda choices: choices[-1],
+        )
+
+        self.assertEqual(rendered, 'Hello {{firstName}}, short note')
+
+    def test_send_email_step_applies_spintax_after_merge_tags(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Spintax flow',
+            status='ACTIVE',
+        )
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='sender-spintax@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+        )
+        campaign.connected_account = account
+        campaign.save(update_fields=['connected_account'])
+        email_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='{Hi|Hello} {{firstName}}',
+            template_body='{Quick|Short} note for {{company}}',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='spintax@acme.test',
+            first_name='Ari',
+            company='Acme',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=email_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+
+        with patch('campaigns.spintax.random.choice', side_effect=lambda choices: choices[0]):
+            with patch('campaigns.tasks.send_gmail', return_value='msg-spintax') as mocked_send:
+                send_email_step(campaign_lead.id, email_step.id)
+
+        mocked_send.assert_called_once()
+        _, to_email, subject, body = mocked_send.call_args.args[:4]
+        self.assertEqual(to_email, 'spintax@acme.test')
+        self.assertEqual(subject, 'Hi Ari')
+        self.assertEqual(body, 'Quick note for Acme')
 
     def test_create_campaign_rejects_connected_account_not_owned_by_current_user(self):
         teammate = User.objects.create_user(

--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -1130,6 +1130,50 @@
             return `${value.slice(0, limit)}...`;
         }
 
+        const SPINTAX_SAMPLE_LEAD = {
+            firstName: 'Ari',
+            lastName: 'Sharma',
+            email: 'ari@example.com',
+            company: 'Acme',
+            icebreaker: 'your recent launch caught my eye',
+        };
+
+        function parseSpintax(text) {
+            let rendered = String(text || '');
+            const pattern = /\{([^{}]*\|[^{}]*)\}/;
+            for (let i = 0; i < 25; i += 1) {
+                const match = rendered.match(pattern);
+                if (!match) break;
+                const choices = match[1].split('|');
+                const choice = choices[Math.floor(Math.random() * choices.length)] || '';
+                rendered = `${rendered.slice(0, match.index)}${choice}${rendered.slice(match.index + match[0].length)}`;
+            }
+            return rendered;
+        }
+
+        function applyPreviewMergeTags(text) {
+            return String(text || '')
+                .replaceAll('{{firstName}}', SPINTAX_SAMPLE_LEAD.firstName)
+                .replaceAll('{{first_name}}', SPINTAX_SAMPLE_LEAD.firstName)
+                .replaceAll('{{lastName}}', SPINTAX_SAMPLE_LEAD.lastName)
+                .replaceAll('{{last_name}}', SPINTAX_SAMPLE_LEAD.lastName)
+                .replaceAll('{{email}}', SPINTAX_SAMPLE_LEAD.email)
+                .replaceAll('{{company}}', SPINTAX_SAMPLE_LEAD.company)
+                .replaceAll('{{icebreaker}}', SPINTAX_SAMPLE_LEAD.icebreaker);
+        }
+
+        function renderSpintaxPreview(step) {
+            const preview = document.getElementById('spintax-preview');
+            if (!preview) return;
+            const subject = parseSpintax(applyPreviewMergeTags(step.subject || ''));
+            const body = parseSpintax(applyPreviewMergeTags(step.body || ''));
+            preview.innerHTML = `
+                <div class="fw-semibold mb-1">${escapeHtml(subject || '(empty subject)')}</div>
+                <div style="white-space:pre-wrap;">${escapeHtml(body || '(empty body)')}</div>
+            `;
+            preview.classList.remove('d-none');
+        }
+
         const SEQUENCE_TEMPLATES = [
             {
                 key: 'quick-touch',
@@ -1711,6 +1755,12 @@
                         <span class="merge-tag" data-tag="{{icebreaker}}"><i class="bi bi-stars me-1"></i>{{icebreaker}}</span>
                     </div>
                 </div>
+                <div class="mb-3">
+                    <button class="btn btn-sm btn-outline-secondary" id="spintax-preview-btn">
+                        <i class="bi bi-shuffle me-1"></i> Preview variation
+                    </button>
+                    <div id="spintax-preview" class="d-none mt-2 p-3 rounded-3 border bg-light small"></div>
+                </div>
 
                 <!-- AI Generation Result -->
                 <div id="ai-result" class="d-none mb-3">
@@ -1751,6 +1801,7 @@
 
             // AI Generate button
             document.getElementById('ai-generate-btn').addEventListener('click', () => openAIComposer(step));
+            document.getElementById('spintax-preview-btn').addEventListener('click', () => renderSpintaxPreview(step));
         }
 
         function renderWaitEditor(panel, step) {
@@ -2283,4 +2334,3 @@
 </body>
 
 </html>
-


### PR DESCRIPTION
## Summary
- add a backend `parse_spintax()` utility for simple and nested `{A|B}` variants
- apply spintax after merge-tag/personalization output before Gmail dispatch
- add a campaign builder "Preview variation" button that resolves sample merge tags and rotates spintax locally
- cover parser behavior and email dispatch integration with campaign tests

## Why
Email templates could store merge tags, but there was no content rotation step. Every recipient received the same resolved copy, which reduces deliverability for outbound campaigns. This adds controlled variation while keeping merge tags intact until send-time personalization runs.

## Validation
- `/opt/homebrew/bin/python3.14 -m venv .venv && .venv/bin/pip install -r requirements.txt`
- `.venv/bin/python backend/manage.py test campaigns` -> 35 passed
- `cd backend && ../.venv/bin/python manage.py test` -> 43 passed
- `.venv/bin/python -m py_compile backend/campaigns/tasks.py backend/campaigns/spintax.py backend/campaigns/tests.py`
- `node --check /tmp/leadorbit-campaign-builder.js`
- `git diff --check`

Closes #122
