### PR TITLE
Add CSV custom variable support

### DIFF
--- a/backend/campaigns/ai.py
+++ b/backend/campaigns/ai.py
@@ -6,6 +6,7 @@ import requests
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
+MERGE_TAG_PATTERN = re.compile(r'{{\s*([a-zA-Z0-9_]+)\s*}}')
 
 
 def _get_gemini_api_key():
@@ -182,19 +183,34 @@ def _apply_merge_tags(text, lead):
     last_name = lead.last_name or ""
     company = lead.company or ""
     email = lead.email or ""
+    custom_variables = getattr(lead, 'custom_variables', {})
 
-    replacements = {
-        "{{first_name}}": first_name,
-        "{{firstName}}": first_name,
-        "{{last_name}}": last_name,
-        "{{lastName}}": last_name,
-        "{{company}}": company,
-        "{{email}}": email,
+    standard_replacements = {
+        "first_name": first_name,
+        "firstName": first_name,
+        "last_name": last_name,
+        "lastName": last_name,
+        "company": company,
+        "email": email,
     }
+    custom_replacements = {}
+    if isinstance(custom_variables, dict):
+        for key, value in custom_variables.items():
+            normalized_key = re.sub(r'[^a-z0-9]+', '_', str(key or '').strip().lower()).strip('_')
+            if not normalized_key:
+                continue
+            custom_replacements[normalized_key] = '' if value is None else str(value)
 
-    for token, value in replacements.items():
-        base = base.replace(token, value)
-    return base
+    def replace_match(match):
+        token = match.group(1)
+        if token in standard_replacements:
+            return standard_replacements[token]
+        normalized_token = re.sub(r'[^a-z0-9]+', '_', token.strip().lower()).strip('_')
+        if normalized_token in custom_replacements:
+            return custom_replacements[normalized_token]
+        return match.group(0)
+
+    return MERGE_TAG_PATTERN.sub(replace_match, base)
 
 
 def personalize_email(template_subject, template_body, lead):
@@ -202,11 +218,10 @@ def personalize_email(template_subject, template_body, lead):
     Uses Gemini to personalize the given email template for a specific lead.
     """
     api_key = _get_gemini_api_key()
+    merged_subject = _apply_merge_tags(template_subject, lead)
+    merged_body = _apply_merge_tags(template_body, lead)
     if not api_key or not template_body:
-        # Fallback to simple formatting if no real key is set
-        subject = _apply_merge_tags(template_subject, lead)
-        body = _apply_merge_tags(template_body, lead)
-        return subject, body
+        return merged_subject, merged_body
         
     prompt = f"""
 You are an expert sales representative. Personalize the following email template for a lead.
@@ -214,9 +229,9 @@ Lead details:
 Name: {lead.first_name} {lead.last_name}
 Company: {lead.company}
 
-Original Subject: {template_subject}
+Original Subject: {merged_subject}
 Original Body:
-{template_body}
+{merged_body}
 
 Requirements:
 - Keep the core message intact.
@@ -250,10 +265,9 @@ Requirements:
             text = text[7:-3]
         
         result = json.loads(text)
-        return result.get("subject", template_subject), result.get("body", template_body)
+        subject = _apply_merge_tags(result.get("subject", merged_subject), lead)
+        body = _apply_merge_tags(result.get("body", merged_body), lead)
+        return subject, body
     except Exception as e:
         logger.error(f"Gemini Personalization Error: {e}")
-        # Fallback to standard merge tags
-        subject = _apply_merge_tags(template_subject, lead)
-        body = _apply_merge_tags(template_body, lead)
-        return subject, body
+        return merged_subject, merged_body

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -5,7 +5,7 @@ from celery import shared_task
 from django.conf import settings as django_settings
 from django.utils import timezone
 
-from .ai import personalize_email
+from .ai import _apply_merge_tags, personalize_email
 from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
 from .sms_service import send_sms, initiate_call
 from .models import CampaignLead, SequenceStep
@@ -317,16 +317,7 @@ def _personalize_text(template, lead):
     """Replace merge tags in SMS/call text with lead data."""
     if not template:
         return template
-    replacements = {
-        '{{firstName}}': lead.first_name or '',
-        '{{lastName}}': lead.last_name or '',
-        '{{email}}': lead.email or '',
-        '{{company}}': lead.company or '',
-    }
-    text = template
-    for tag, value in replacements.items():
-        text = text.replace(tag, value)
-    return text
+    return _apply_merge_tags(template, lead)
 
 
 def _execute_sms_step(clead, step, now=None):

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from campaigns.models import Campaign, CampaignLead, ConnectedEmailAccount, SequenceStep
+from campaigns.ai import personalize_email
 from campaigns.tasks import (
     _get_campaign_steps,
     poll_gmail_for_replies,
@@ -111,6 +112,26 @@ class CampaignWorkflowTests(APITestCase):
                 self.assertEqual(steps[index].delay_minutes, delay_minutes)
                 self.assertEqual(steps[index].template_subject or '', subject)
                 self.assertEqual(steps[index].template_body or '', body)
+
+    def test_personalize_email_replaces_custom_variables(self):
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='custom-vars@acme.test',
+            first_name='Casey',
+            custom_variables={
+                'industry': 'SaaS',
+                'meeting_time': '10:30 AM',
+            },
+        )
+
+        subject, body = personalize_email(
+            'Hello {{firstName}} from {{industry}}',
+            'Can we talk at {{meeting_time}}?',
+            lead,
+        )
+
+        self.assertEqual(subject, 'Hello Casey from SaaS')
+        self.assertEqual(body, 'Can we talk at 10:30 AM?')
 
     def test_process_active_leads_advances_all_non_email_step_types(self):
         campaign = Campaign.objects.create(

--- a/backend/leads/migrations/0002_lead_custom_variables.py
+++ b/backend/leads/migrations/0002_lead_custom_variables.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('leads', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='lead',
+            name='custom_variables',
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/backend/leads/models.py
+++ b/backend/leads/models.py
@@ -11,6 +11,7 @@ class Lead(TenantModel):
     phone = models.CharField(max_length=50, blank=True, null=True)
     linkedin_url = models.URLField(max_length=255, blank=True, null=True)
     custom_data = models.JSONField(default=dict, blank=True)
+    custom_variables = models.JSONField(default=dict, blank=True)
     global_unsubscribe = models.BooleanField(default=False)
     score = models.IntegerField(default=0)
 

--- a/backend/leads/serializers.py
+++ b/backend/leads/serializers.py
@@ -11,7 +11,7 @@ class LeadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Lead
-        fields = ['id', 'email', 'first_name', 'last_name', 'company', 'phone', 'linkedin_url', 'custom_data', 'global_unsubscribe', 'score', 'tags', 'created_at']
+        fields = ['id', 'email', 'first_name', 'last_name', 'company', 'phone', 'linkedin_url', 'custom_data', 'custom_variables', 'global_unsubscribe', 'score', 'tags', 'created_at']
         read_only_fields = ['organization', 'score']
 
     def get_tags(self, obj):

--- a/backend/leads/tasks.py
+++ b/backend/leads/tasks.py
@@ -8,9 +8,29 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+STANDARD_FIELD_ALIASES = {
+    'email': ('email', 'work_email', 'email_address'),
+    'first_name': ('firstName', 'first_name', 'firstname', 'first name'),
+    'last_name': ('lastName', 'last_name', 'lastname', 'last name'),
+    'company': ('companyName', 'company', 'company_name', 'organization'),
+    'linkedin_url': ('linkedinUrl', 'linkedin_url', 'linkedin', 'linkedin_profile'),
+    'phone': ('phone', 'phoneNumber', 'phone_number', 'mobile', 'phone number'),
+}
+
 
 def _normalize_key(value):
     return re.sub(r'[^a-z0-9]', '', (value or '').strip().lower())
+
+
+def _normalize_custom_variable_key(value):
+    return re.sub(r'[^a-z0-9]+', '_', (value or '').strip().lower()).strip('_')
+
+
+STANDARD_CSV_HEADERS = {
+    _normalize_key(alias)
+    for aliases in STANDARD_FIELD_ALIASES.values()
+    for alias in aliases
+}
 
 
 def _normalize_row(row):
@@ -27,6 +47,18 @@ def _get_field(row, *keys):
         if val:
             return val
     return ''
+
+
+def _extract_custom_variables(row):
+    custom_variables = {}
+    for key, value in row.items():
+        if _normalize_key(key) in STANDARD_CSV_HEADERS:
+            continue
+        custom_key = _normalize_custom_variable_key(key)
+        if not custom_key:
+            continue
+        custom_variables[custom_key] = (value or '').strip()
+    return custom_variables
 
 
 @shared_task
@@ -60,6 +92,7 @@ def import_leads_from_csv(file_contents, organization_id):
         company = _get_field(normalized_row, 'companyName', 'company', 'company_name', 'organization')
         linkedin_url = _get_field(normalized_row, 'linkedinUrl', 'linkedin_url', 'linkedin', 'linkedin_profile')
         phone = _get_field(normalized_row, 'phone', 'phoneNumber', 'phone_number', 'mobile', 'phone number')
+        custom_variables = _extract_custom_variables(row)
 
         # Normalize phone to E.164 format (add +91 for 10-digit Indian numbers)
         if phone and not phone.startswith('+'):
@@ -81,6 +114,7 @@ def import_leads_from_csv(file_contents, organization_id):
                 'company': company,
                 'linkedin_url': linkedin_url or None,
                 'phone': phone or None,
+                'custom_variables': custom_variables,
             }
         )
         if created:

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -26,6 +26,24 @@ class LeadImportTests(APITestCase):
         self.assertEqual(lead.linkedin_url, 'https://linkedin.com/in/alice')
         self.assertEqual(lead.phone, '+123456789')
 
+    def test_import_stores_non_standard_headers_as_custom_variables(self):
+        csv_data = (
+            "email,first_name,Industry,Meeting Time,Lead Source\n"
+            "bob@example.com,Bob,SaaS,10:30 AM,Referral\n"
+        )
+
+        import_leads_from_csv(csv_data, str(self.organization.id))
+
+        lead = Lead.objects.get(organization=self.organization, email='bob@example.com')
+        self.assertEqual(
+            lead.custom_variables,
+            {
+                'industry': 'SaaS',
+                'meeting_time': '10:30 AM',
+                'lead_source': 'Referral',
+            },
+        )
+
 
 class LeadIsolationAPITests(APITestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Adds support for importing custom CSV columns as lead-level variables and using them in campaign email templates.
Closes #125 

## Changes

- Added `custom_variables` JSON field to `Lead`.
- Added migration for the new field.
- Updated CSV import to store non-standard headers as custom variables.
- Normalizes custom CSV headers to snake_case, e.g. `Meeting Time` -> `meeting_time`.
- Updated merge-tag rendering to replace custom tags like `{{industry}}` and `{{meeting_time}}`.
- Added focused tests for CSV import and template interpolation.

## Validation

- `python manage.py makemigrations --check`
- `python manage.py test leads.tests campaigns.tests`

## Notes

Standard lead fields such as email, first name, last name, company, phone, and LinkedIn URL continue to import normally. Extra CSV columns are stored separately in `custom_variables`.