### PR TITLE
fix: log bounce details on webhooks

### DIFF
--- a/backend/campaigns/migrations/0007_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0007_campaignlead_bounce_metadata.py
@@ -1,0 +1,22 @@
+# Generated manually for bounce metadata tracking
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("campaigns", "0006_alter_sequencestep_channel_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="campaignlead",
+            name="bounce_reason",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="campaignlead",
+            name="bounce_type",
+            field=models.CharField(blank=True, max_length=20, null=True),
+        ),
+    ]

--- a/backend/campaigns/models.py
+++ b/backend/campaigns/models.py
@@ -88,6 +88,8 @@ class CampaignLead(TenantModel):
     last_opened_at = models.DateTimeField(null=True, blank=True)
     last_clicked_at = models.DateTimeField(null=True, blank=True)
     last_replied_at = models.DateTimeField(null=True, blank=True)
+    bounce_type = models.CharField(max_length=20, null=True, blank=True)
+    bounce_reason = models.TextField(null=True, blank=True)
 
     class Meta:
         unique_together = ('campaign', 'lead')

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -448,6 +448,47 @@ class CampaignWorkflowTests(APITestCase):
             process_active_leads()
             mocked_delay.assert_called_once_with(campaign_lead.id, email_step.id)
 
+    def test_webhook_bounce_persists_reason_and_type(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Bounce webhook flow',
+            status='ACTIVE',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='bounce@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            status='ACTIVE',
+            last_sent_message_id='msg-bounce-1',
+        )
+
+        response = self.client.post(
+            '/api/v1/webhooks/email/',
+            {
+                'event': 'bounce',
+                'email': 'bounce@acme.test',
+                'message_id': 'msg-bounce-1',
+                'bounce': {
+                    'type': 'soft',
+                    'description': 'Mailbox full',
+                    'code': '4.2.2',
+                },
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        campaign_lead.refresh_from_db()
+        self.assertEqual(campaign_lead.status, 'BOUNCED')
+        self.assertIsNone(campaign_lead.current_step)
+        self.assertIsNone(campaign_lead.next_execution_time)
+        self.assertEqual(campaign_lead.bounce_type, 'soft')
+        self.assertEqual(campaign_lead.bounce_reason, 'Mailbox full')
+
     def test_create_campaign_rejects_connected_account_not_owned_by_current_user(self):
         teammate = User.objects.create_user(
             email='teammate@acme.test',

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -7,6 +9,8 @@ from leads.models import Lead
 
 from .models import Campaign, CampaignLead, SequenceStep
 from .serializers import CampaignSerializer, SequenceStepSerializer
+
+logger = logging.getLogger(__name__)
 
 class CampaignViewSet(viewsets.ModelViewSet):
     serializer_class = CampaignSerializer
@@ -211,6 +215,34 @@ class WebhookView(APIView):
     to track opens, clicks, bounces.
     """
     permission_classes = [AllowAny] # Webhooks need to be publicly accessible
+
+    @staticmethod
+    def _extract_bounce_metadata(payload):
+        bounce_data = payload.get('bounce')
+        if not isinstance(bounce_data, dict):
+            bounce_data = {}
+
+        bounce_type = (
+            payload.get('bounce_type')
+            or payload.get('type')
+            or bounce_data.get('type')
+            or bounce_data.get('bounce_type')
+            or ''
+        )
+        bounce_reason = (
+            payload.get('bounce_reason')
+            or payload.get('reason')
+            or payload.get('description')
+            or payload.get('smtp_response')
+            or bounce_data.get('reason')
+            or bounce_data.get('description')
+            or bounce_data.get('smtp_response')
+            or bounce_data.get('status')
+            or bounce_data.get('code')
+            or ''
+        )
+
+        return str(bounce_type).strip().lower(), str(bounce_reason).strip()
     
     def post(self, request, *args, **kwargs):
         event_type = (request.data.get('event') or '').strip().lower()
@@ -239,8 +271,19 @@ class WebhookView(APIView):
 
                 for cl in cleads:
                     if event_type == 'bounce':
+                        bounce_type, bounce_reason = self._extract_bounce_metadata(request.data)
                         cl.status = 'BOUNCED'
-                        cl.save(update_fields=['status'])
+                        cl.current_step = None
+                        cl.next_execution_time = None
+                        cl.bounce_type = bounce_type or None
+                        cl.bounce_reason = bounce_reason or None
+                        cl.save(update_fields=['status', 'current_step', 'next_execution_time', 'bounce_type', 'bounce_reason'])
+                        logger.info(
+                            "Bounce detected for %s | type=%s | reason=%s",
+                            cl.lead.email,
+                            bounce_type or 'unknown',
+                            bounce_reason or 'unspecified',
+                        )
                     elif event_type == 'reply':
                         cl.last_replied_at = now
                         # Only hard-stop if there is no reply-yes branch configured.


### PR DESCRIPTION
Adds bounce_type and bounce_reason to CampaignLead, persists bounce metadata from webhook payloads, and covers the nested bounce payload shape in tests.\n\nValidation:\n- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 backend/manage.py test campaigns\n- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 manage.py test (from backend/)