### PR TITLE
LO-033: Add dynamic merge tag selector in email editor UI

### DIFF
--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -1686,6 +1686,18 @@
                         </button>
                     </div>
                 </div>
+
+                <div class="mb-3">
+                    <div class="ep-label">Insert Tag</div>
+                        <select class="ep-input" id="merge-tag-select">
+                            <option value="">Select a merge tag</option>
+                            <option value="{{firstName}}">{{firstName}}</option>
+                            <option value="{{lastName}}">{{lastName}}</option>
+                            <option value="{{email}}">{{email}}</option>
+                            <option value="{{company}}">{{company}}</option>
+                            <option value="{{icebreaker}}">{{icebreaker}}</option>
+                        </select>
+                </div>
                 <div class="mb-3">
                     <div class="ep-label">Subject <span class="text-muted fw-normal">&middot; Add Cc</span></div>
                     <input type="text" class="ep-input" id="ep-subject" placeholder="Subject" value="${step.subject || ''}">
@@ -1721,6 +1733,47 @@
             // Bind inputs
             document.getElementById('ep-subject').addEventListener('input', (e) => { step.subject = e.target.value; });
             document.getElementById('ep-body').addEventListener('input', (e) => { step.body = e.target.value; });
+
+            let activeEditor = document.getElementById('ep-body');
+
+            document.getElementById('ep-subject').addEventListener('focus', () => {
+                activeEditor = document.getElementById('ep-subject');
+            });
+
+            document.getElementById('ep-body').addEventListener('focus', () => {
+                activeEditor = document.getElementById('ep-body');
+            });
+
+
+
+            const mergeSelect = document.getElementById('merge-tag-select');
+
+            mergeSelect.addEventListener('change', (e) => {
+                const tagText = e.target.value;
+                if (!tagText) return;
+
+            const body = activeEditor;
+
+            const start = body.selectionStart;
+            const end = body.selectionEnd;
+
+            body.value =
+                body.value.substring(0, start) +
+                tagText +
+                body.value.substring(end);
+
+            if (body.id === 'ep-subject') {
+                step.subject = body.value;
+            } else {
+                step.body = body.value;
+            }
+
+            body.focus();
+            body.selectionStart = body.selectionEnd =
+                start + tagText.length;
+
+            mergeSelect.value = '';
+        });
             const senderSelect = document.getElementById('sender-account-select');
             if (senderSelect) {
                 senderSelect.addEventListener('change', (e) => {


### PR DESCRIPTION
## Description

This PR implements a dynamic merge tag selector in the Campaign Builder Email Editor UI.

### Changes Made

* Added an **"Insert Tag"** dropdown above the email subject and body editors.
* Added commonly used merge tags:

  * `{{firstName}}`
  * `{{lastName}}`
  * `{{email}}`
  * `{{company}}`
  * `{{icebreaker}}`
* Implemented JavaScript functionality to insert the selected merge tag at the current cursor position.
* Added support for inserting tags into the currently focused editor field (Subject or Body).
* Preserved the existing merge tag chip functionality.

### Files Modified

* `frontend/campaign-builder.html`

### Testing Performed

* Verified the "Insert Tag" dropdown renders correctly.
* Verified merge tags are inserted at the cursor position.
* Tested insertion inside the Subject field.
* Tested insertion inside the Body field.
* Tested multiple merge tag selections.
* Confirmed existing editor functionality remains unaffected.
* Confirmed no console errors during testing.


### Issue

Closes #124
