### PR TITLE
feat: add lead import history

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -10,7 +10,7 @@ class CustomTokenObtainPairView(BaseTokenObtainPairView):
     serializer_class = CustomTokenObtainSerializer
 
 from users.views import AuthViewSet
-from leads.views import LeadViewSet, TagViewSet
+from leads.views import LeadImportJobViewSet, LeadViewSet, TagViewSet
 from campaigns.views import (
     CampaignViewSet,
     SequenceStepViewSet,
@@ -32,6 +32,7 @@ def api_root(_request):
 router = DefaultRouter()
 router.register(r'auth', AuthViewSet, basename='auth')
 router.register(r'leads', LeadViewSet, basename='leads')
+router.register(r'lead-import-jobs', LeadImportJobViewSet, basename='lead-import-jobs')
 router.register(r'tags', TagViewSet, basename='tags')
 router.register(r'campaigns', CampaignViewSet, basename='campaigns')
 
@@ -52,4 +53,3 @@ urlpatterns = [
     path('api/v1/unsubscribe/<uuid:lead_id>/<str:token>/', unsubscribe_view, name='unsubscribe'),
     path('api/v1/', include(router.urls)),
 ]
-

--- a/backend/leads/migrations/0002_leadimportjob.py
+++ b/backend/leads/migrations/0002_leadimportjob.py
@@ -1,0 +1,45 @@
+# Generated manually for CSV import history tracking
+
+import django.db.models.deletion
+import uuid
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("leads", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="LeadImportJob",
+            fields=[
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("filename", models.CharField(max_length=255)),
+                ("total_rows", models.IntegerField(default=0)),
+                ("imported_count", models.IntegerField(default=0)),
+                ("failed_count", models.IntegerField(default=0)),
+                ("error_log", models.JSONField(blank=True, default=list)),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tenants.organization",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/backend/leads/models.py
+++ b/backend/leads/models.py
@@ -20,6 +20,20 @@ class Lead(TenantModel):
     def __str__(self):
         return f"{self.first_name} {self.last_name} ({self.email})"
 
+class LeadImportJob(TenantModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    filename = models.CharField(max_length=255)
+    total_rows = models.IntegerField(default=0)
+    imported_count = models.IntegerField(default=0)
+    failed_count = models.IntegerField(default=0)
+    error_log = models.JSONField(default=list, blank=True)
+
+    class Meta:
+        ordering = ['-created_at']
+
+    def __str__(self):
+        return f"{self.filename} ({self.created_at:%Y-%m-%d %H:%M})"
+
 class Tag(TenantModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=50)

--- a/backend/leads/serializers.py
+++ b/backend/leads/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Lead, Tag, LeadTag
+from .models import Lead, LeadImportJob, Tag, LeadTag
 
 class TagSerializer(serializers.ModelSerializer):
     class Meta:
@@ -17,3 +17,17 @@ class LeadSerializer(serializers.ModelSerializer):
     def get_tags(self, obj):
         tags = Tag.objects.filter(tagged_leads__lead=obj)
         return TagSerializer(tags, many=True).data
+
+
+class LeadImportJobSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LeadImportJob
+        fields = [
+            'id',
+            'filename',
+            'total_rows',
+            'imported_count',
+            'failed_count',
+            'error_log',
+            'created_at',
+        ]

--- a/backend/leads/tasks.py
+++ b/backend/leads/tasks.py
@@ -2,7 +2,10 @@ import csv
 import io
 import re
 from celery import shared_task
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from .models import Lead
+from .models import LeadImportJob
 from tenants.models import Organization
 import logging
 
@@ -30,8 +33,14 @@ def _get_field(row, *keys):
 
 
 @shared_task
-def import_leads_from_csv(file_contents, organization_id):
+def import_leads_from_csv(file_contents, organization_id, import_job_id=None, filename=''):
     org = Organization.objects.get(id=organization_id)
+    import_job = None
+    if import_job_id:
+        try:
+            import_job = LeadImportJob.objects.get(id=import_job_id, organization=org)
+        except LeadImportJob.DoesNotExist:
+            import_job = None
 
     # Parse the CSV contents
     file_contents = file_contents.lstrip('\ufeff')
@@ -46,12 +55,42 @@ def import_leads_from_csv(file_contents, organization_id):
     leads_created = 0
     leads_updated = 0
     skipped = 0
+    total_rows = 0
+    error_log = []
+    seen_emails = set()
 
-    for row in reader:
+    for row_number, row in enumerate(reader, start=2):
+        total_rows += 1
         normalized_row = _normalize_row(row)
         email = _get_field(normalized_row, 'email', 'work_email', 'email_address')
         if not email:
             skipped += 1
+            error_log.append({
+                'row': row_number,
+                'email': '',
+                'error': 'Email is required',
+            })
+            continue
+
+        if email.lower() in seen_emails:
+            skipped += 1
+            error_log.append({
+                'row': row_number,
+                'email': email,
+                'error': 'Duplicate email in CSV',
+            })
+            continue
+        seen_emails.add(email.lower())
+
+        try:
+            validate_email(email)
+        except ValidationError:
+            skipped += 1
+            error_log.append({
+                'row': row_number,
+                'email': email,
+                'error': 'Invalid email format',
+            })
             continue
 
         # Flexible aliases for common exports (Lemlist, HubSpot, custom CSVs)
@@ -72,22 +111,40 @@ def import_leads_from_csv(file_contents, organization_id):
                 phone = '+' + phone  # best-effort prefix
 
         # Create or update Lead for this organization
-        _, created = Lead.objects.update_or_create(
-            organization=org,
-            email=email,
-            defaults={
-                'first_name': first_name,
-                'last_name': last_name,
-                'company': company,
-                'linkedin_url': linkedin_url or None,
-                'phone': phone or None,
-            }
-        )
+        try:
+            _, created = Lead.objects.update_or_create(
+                organization=org,
+                email=email,
+                defaults={
+                    'first_name': first_name,
+                    'last_name': last_name,
+                    'company': company,
+                    'linkedin_url': linkedin_url or None,
+                    'phone': phone or None,
+                }
+            )
+        except Exception as exc:
+            skipped += 1
+            error_log.append({
+                'row': row_number,
+                'email': email,
+                'error': str(exc),
+            })
+            logger.exception("Lead import failed for %s row %s", email, row_number)
+            continue
+
         if created:
             leads_created += 1
         else:
             leads_updated += 1
 
     summary = f"Processed {leads_created} new, {leads_updated} updated, {skipped} skipped for organization {org.name}"
+    if import_job:
+        import_job.filename = filename or import_job.filename
+        import_job.total_rows = total_rows
+        import_job.imported_count = leads_created + leads_updated
+        import_job.failed_count = skipped
+        import_job.error_log = error_log
+        import_job.save(update_fields=['filename', 'total_rows', 'imported_count', 'failed_count', 'error_log', 'updated_at'])
     logger.info(summary)
     return summary

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from leads.models import Lead
+from leads.models import Lead, LeadImportJob
 from leads.tasks import import_leads_from_csv
 from tenants.models import Organization
 from users.models import User
@@ -25,6 +25,33 @@ class LeadImportTests(APITestCase):
         self.assertEqual(lead.company, 'Acme')
         self.assertEqual(lead.linkedin_url, 'https://linkedin.com/in/alice')
         self.assertEqual(lead.phone, '+123456789')
+
+    def test_import_records_row_errors_in_import_job_history(self):
+        job = LeadImportJob.objects.create(
+            organization=self.organization,
+            filename='prospects.csv',
+        )
+
+        csv_data = (
+            "email,first_name,company\n"
+            "valid@example.com,Alice,Acme\n"
+            "invalid-email,Bob,Acme\n"
+            "valid@example.com,Duplicate,Acme\n"
+            ",NoEmail,Acme\n"
+        )
+
+        import_leads_from_csv(csv_data, str(self.organization.id), str(job.id), 'prospects.csv')
+
+        job.refresh_from_db()
+        self.assertEqual(job.filename, 'prospects.csv')
+        self.assertEqual(job.total_rows, 4)
+        self.assertEqual(job.imported_count, 1)
+        self.assertEqual(job.failed_count, 3)
+        self.assertEqual(len(job.error_log), 3)
+        self.assertTrue(any(item['error'] == 'Invalid email format' for item in job.error_log))
+        self.assertTrue(any(item['error'] == 'Duplicate email in CSV' for item in job.error_log))
+        self.assertTrue(any(item['error'] == 'Email is required' for item in job.error_log))
+        self.assertEqual(Lead.objects.filter(organization=self.organization).count(), 1)
 
 
 class LeadIsolationAPITests(APITestCase):
@@ -88,3 +115,28 @@ class LeadIsolationAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(Lead.objects.filter(id=self.lead_a.id).exists())
         self.assertTrue(Lead.objects.filter(id=self.lead_b.id).exists())
+
+    def test_import_history_is_paginated_and_scoped_to_organization(self):
+        LeadImportJob.objects.create(
+            organization=self.org_a,
+            filename='org-a.csv',
+            total_rows=2,
+            imported_count=2,
+            failed_count=0,
+            error_log=[],
+        )
+        LeadImportJob.objects.create(
+            organization=self.org_b,
+            filename='org-b.csv',
+            total_rows=3,
+            imported_count=2,
+            failed_count=1,
+            error_log=[{'row': 3, 'email': 'bad@example.com', 'error': 'Invalid email format'}],
+        )
+
+        self.client.force_authenticate(self.user_a)
+        response = self.client.get('/api/v1/lead-import-jobs/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['filename'], 'org-a.csv')

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -1,8 +1,13 @@
 from rest_framework import viewsets, parsers, status
 from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
-from .models import Lead, Tag
-from .serializers import LeadSerializer, TagSerializer
+from .models import Lead, LeadImportJob, Tag
+from .serializers import LeadImportJobSerializer, LeadSerializer, TagSerializer
+
+
+class LeadImportJobPagination(PageNumberPagination):
+    page_size = 10
 
 class LeadViewSet(viewsets.ModelViewSet):
     serializer_class = LeadSerializer
@@ -29,14 +34,40 @@ class LeadViewSet(viewsets.ModelViewSet):
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
         
+        import_job = LeadImportJob.objects.create(
+            organization=request.user.organization,
+            filename=file_obj.name,
+        )
+
         # Trigger async celery task
         from .tasks import import_leads_from_csv
         file_contents = file_obj.read().decode('utf-8')
         
         # Ensure we pass the organization to the task
-        import_leads_from_csv.delay(file_contents, request.user.organization.id)
+        import_leads_from_csv.delay(
+            file_contents,
+            request.user.organization.id,
+            str(import_job.id),
+            file_obj.name,
+        )
         
-        return Response({"message": "File received. Processing in background.", "filename": file_obj.name}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {
+                "message": "File received. Processing in background.",
+                "filename": file_obj.name,
+                "job_id": str(import_job.id),
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+
+class LeadImportJobViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = LeadImportJobSerializer
+    pagination_class = LeadImportJobPagination
+    queryset = LeadImportJob.objects.all()
+
+    def get_queryset(self):
+        return LeadImportJob.objects.filter(organization=self.request.user.organization)
 
 class TagViewSet(viewsets.ModelViewSet):
     serializer_class = TagSerializer

--- a/frontend/leads.html
+++ b/frontend/leads.html
@@ -68,6 +68,9 @@
                                 <input type="text" id="lead-search" class="form-control" placeholder="Search name, email, company">
                             </div>
                         </div>
+                        <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#historyModal">
+                            <i class="bi bi-clock-history me-1"></i> Import History
+                        </button>
                         <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#uploadModal">
                             <i class="bi bi-upload me-1"></i> Import CSV
                         </button>
@@ -164,11 +167,78 @@
         </div>
     </div>
 
+    <div class="modal fade" id="historyModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+            <div class="modal-content rounded-3 shadow">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title fw-bold">Import History</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body pt-0">
+                    <div class="row g-3">
+                        <div class="col-lg-7">
+                            <div class="table-responsive border rounded-3">
+                                <table class="table table-hover mb-0 align-middle">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>File</th>
+                                            <th>Imported</th>
+                                            <th>Failed</th>
+                                            <th>When</th>
+                                            <th></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="history-table-body">
+                                        <tr>
+                                            <td colspan="5" class="text-center py-4 text-muted">
+                                                Loading import history...
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="d-flex justify-content-between align-items-center gap-2 mt-3">
+                                <small id="history-page-summary" class="text-muted"></small>
+                                <div class="btn-group btn-group-sm">
+                                    <button class="btn btn-outline-secondary" id="history-prev-btn" type="button">
+                                        <i class="bi bi-chevron-left"></i>
+                                    </button>
+                                    <button class="btn btn-outline-secondary" id="history-next-btn" type="button">
+                                        <i class="bi bi-chevron-right"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-lg-5">
+                            <div class="border rounded-3 p-3 h-100 bg-body-tertiary" id="history-detail-pane">
+                                <div class="text-muted text-center py-5">
+                                    Select an import job to inspect its error log.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script type="module" src="/main.js"></script>
     <script type="module">
         import { fetchWithAuth } from '/api.js';
 
         let allLeads = [];
+        let importJobs = [];
+        let selectedImportJob = null;
+        let importHistoryPage = 1;
+        let importHistoryCount = 0;
+        const importHistoryPageSize = 10;
+
+        const escapeHtml = (value) => String(value ?? '')
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
 
         function copyToClipboard(text, button) {
             navigator.clipboard.writeText(text).then(() => {
@@ -251,6 +321,137 @@
             document.getElementById('avg-score').textContent = avgScore;
         }
 
+        function formatImportDate(value) {
+            if (!value) return 'Just now';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return 'Just now';
+            return date.toLocaleString();
+        }
+
+        function renderImportJobDetail() {
+            const pane = document.getElementById('history-detail-pane');
+            if (!selectedImportJob) {
+                pane.innerHTML = '<div class="text-muted text-center py-5">Select an import job to inspect its error log.</div>';
+                return;
+            }
+
+            const errors = Array.isArray(selectedImportJob.error_log) ? selectedImportJob.error_log : [];
+            const errorList = errors.length > 0
+                ? `<div class="list-group list-group-flush">
+                        ${errors.map(item => `
+                            <div class="list-group-item px-0">
+                                <div class="d-flex justify-content-between align-items-start gap-3">
+                                    <div>
+                                        <div class="fw-semibold">Row ${escapeHtml(item.row)}</div>
+                                        <div class="small text-muted">${escapeHtml(item.email || 'No email supplied')}</div>
+                                    </div>
+                                    <span class="badge bg-light text-danger border border-danger">Failed</span>
+                                </div>
+                                <div class="mt-2">${escapeHtml(item.error || 'Unknown import error')}</div>
+                            </div>
+                        `).join('')}
+                    </div>`
+                : '<div class="alert alert-success mb-0">No errors recorded for this import.</div>';
+
+            pane.innerHTML = `
+                <div class="d-flex justify-content-between align-items-start gap-3">
+                    <div>
+                        <h6 class="mb-1">${escapeHtml(selectedImportJob.filename)}</h6>
+                        <div class="text-muted small">${formatImportDate(selectedImportJob.created_at)}</div>
+                    </div>
+                    <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-target="#uploadModal" data-bs-toggle="modal">
+                        <i class="bi bi-upload me-1"></i> Import CSV
+                    </button>
+                </div>
+                <div class="row g-2 mt-3">
+                    <div class="col-4"><div class="border rounded-3 p-2 text-center"><div class="fw-bold">${Number(selectedImportJob.total_rows) || 0}</div><div class="small text-muted">Rows</div></div></div>
+                    <div class="col-4"><div class="border rounded-3 p-2 text-center"><div class="fw-bold text-success">${Number(selectedImportJob.imported_count) || 0}</div><div class="small text-muted">Imported</div></div></div>
+                    <div class="col-4"><div class="border rounded-3 p-2 text-center"><div class="fw-bold text-danger">${Number(selectedImportJob.failed_count) || 0}</div><div class="small text-muted">Failed</div></div></div>
+                </div>
+                <div class="mt-3">
+                    <div class="small text-uppercase text-muted fw-semibold mb-2">Error Log</div>
+                    ${errorList}
+                </div>
+            `;
+        }
+
+        function renderImportHistory() {
+            const tbody = document.getElementById('history-table-body');
+            const summary = document.getElementById('history-page-summary');
+            const prevBtn = document.getElementById('history-prev-btn');
+            const nextBtn = document.getElementById('history-next-btn');
+            const totalPages = Math.max(1, Math.ceil(importHistoryCount / importHistoryPageSize));
+
+            summary.textContent = importHistoryCount
+                ? `Page ${importHistoryPage} of ${totalPages} • ${importHistoryCount} job${importHistoryCount === 1 ? '' : 's'} total`
+                : 'No import jobs yet';
+            prevBtn.disabled = importHistoryPage <= 1;
+            nextBtn.disabled = importHistoryPage >= totalPages;
+
+            if (importJobs.length === 0) {
+                tbody.innerHTML = `
+                    <tr>
+                        <td colspan="5" class="text-center py-4 text-muted">
+                            No import history found.
+                        </td>
+                    </tr>`;
+                selectedImportJob = null;
+                renderImportJobDetail();
+                return;
+            }
+
+            if (!selectedImportJob || !importJobs.some(job => String(job.id) === String(selectedImportJob.id))) {
+                selectedImportJob = importJobs[0];
+            }
+
+            tbody.innerHTML = importJobs.map(job => {
+                const isSelected = selectedImportJob && String(selectedImportJob.id) === String(job.id);
+                return `
+                    <tr class="${isSelected ? 'table-primary' : ''}" data-job-id="${job.id}">
+                        <td class="fw-semibold">${escapeHtml(job.filename)}</td>
+                        <td>${Number(job.imported_count) || 0}</td>
+                        <td>${Number(job.failed_count) || 0}</td>
+                        <td class="text-muted small">${formatImportDate(job.created_at)}</td>
+                        <td class="text-end">
+                            <button class="btn btn-sm btn-outline-primary view-import-job-btn" data-job-id="${job.id}" type="button">
+                                View log
+                            </button>
+                        </td>
+                    </tr>
+                `;
+            }).join('');
+
+            tbody.querySelectorAll('.view-import-job-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    selectedImportJob = importJobs.find(job => String(job.id) === String(btn.dataset.jobId)) || null;
+                    renderImportHistory();
+                    renderImportJobDetail();
+                });
+            });
+
+            renderImportJobDetail();
+        }
+
+        async function loadImportHistory(page = 1) {
+            const res = await fetchWithAuth(`/lead-import-jobs/?page=${page}`);
+            if (!res.ok) throw new Error('Failed to load import history.');
+
+            const payload = await res.json();
+            importJobs = Array.isArray(payload.results) ? payload.results : (Array.isArray(payload) ? payload : []);
+            importHistoryCount = typeof payload.count === 'number' ? payload.count : importJobs.length;
+            importHistoryPage = page;
+            renderImportHistory();
+        }
+
+        async function loadLeads() {
+            const res = await fetchWithAuth('/leads/');
+            if (!res.ok) throw new Error('Failed to load leads.');
+
+            allLeads = await res.json();
+            renderStats(allLeads);
+            applySearch();
+        }
+
         function applySearch() {
             const q = (document.getElementById('lead-search').value || '').trim().toLowerCase();
             if (!q) {
@@ -266,17 +467,46 @@
 
         document.addEventListener('DOMContentLoaded', async () => {
             try {
-                const res = await fetchWithAuth('/leads/');
-                if (res.ok) {
-                    allLeads = await res.json();
-                    renderStats(allLeads);
-                    renderLeadRows(allLeads);
-                }
+                await loadLeads();
             } catch (e) {
                 console.error('Error fetching leads:', e);
             }
 
             document.getElementById('lead-search').addEventListener('input', applySearch);
+
+            document.getElementById('historyModal').addEventListener('show.bs.modal', async () => {
+                try {
+                    await loadImportHistory(1);
+                } catch (error) {
+                    document.getElementById('history-table-body').innerHTML = `
+                        <tr>
+                            <td colspan="5" class="text-center py-4 text-danger">
+                                ${escapeHtml(error.message || 'Failed to load import history.')}
+                            </td>
+                        </tr>`;
+                }
+            });
+
+            document.getElementById('history-prev-btn').addEventListener('click', async () => {
+                if (importHistoryPage > 1) {
+                    try {
+                        await loadImportHistory(importHistoryPage - 1);
+                    } catch (error) {
+                        console.error(error);
+                    }
+                }
+            });
+
+            document.getElementById('history-next-btn').addEventListener('click', async () => {
+                const totalPages = Math.max(1, Math.ceil(importHistoryCount / importHistoryPageSize));
+                if (importHistoryPage < totalPages) {
+                    try {
+                        await loadImportHistory(importHistoryPage + 1);
+                    } catch (error) {
+                        console.error(error);
+                    }
+                }
+            });
 
             document.getElementById('upload-form').addEventListener('submit', async (e) => {
                 e.preventDefault();
@@ -300,7 +530,9 @@
 
                     if (res.status === 202) {
                         statusEl.innerHTML = '<span class="text-success"><i class="bi bi-check-circle me-1"></i>File uploaded. Processing now...</span>';
-                        setTimeout(() => window.location.reload(), 1800);
+                        await loadLeads();
+                        await loadImportHistory(1);
+                        fileInput.value = '';
                     } else {
                         statusEl.innerHTML = '<span class="text-danger"><i class="bi bi-x-circle me-1"></i>Upload failed.</span>';
                     }


### PR DESCRIPTION
Adds a LeadImportJob history model, records row-level CSV import errors and totals, exposes a paginated import-history API, and adds a Leads-page modal to review previous imports and their error logs.

Validation:
- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 manage.py test leads (from backend/)
- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 manage.py test (from backend/)
- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile /private/tmp/leadorbit-133/backend/leads/models.py /private/tmp/leadorbit-133/backend/leads/serializers.py /private/tmp/leadorbit-133/backend/leads/tasks.py /private/tmp/leadorbit-133/backend/leads/views.py /private/tmp/leadorbit-133/backend/leads/tests.py
- node --check /tmp/leadorbit-leads-module.js