### PR TITLE
feat: add warm-up send limits

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -156,6 +156,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'campaigns.tasks.process_active_leads',
         'schedule': 60.0,
     },
+    'refresh-connected-email-account-warmup-limits-daily': {
+        'task': 'campaigns.tasks.refresh_connected_email_account_warmup_limits',
+        'schedule': 86400.0,
+    },
     'poll-gmail-replies-every-5-minutes': {
         'task': 'campaigns.tasks.poll_gmail_for_replies',
         'schedule': 300.0,

--- a/backend/campaigns/google_auth_views.py
+++ b/backend/campaigns/google_auth_views.py
@@ -313,6 +313,9 @@ class GoogleOAuthCallbackView(APIView):
                     refresh_token=refresh_token or '',
                     token_expiry=token_expiry,
                     provider='GOOGLE',
+                    daily_sending_limit=25,
+                    current_daily_count=0,
+                    warmup_enabled=True,
                 )
                 account.save()
                 action = 'connected'
@@ -380,6 +383,9 @@ class ConnectedAccountsListView(APIView):
                 'email': a.email_address,
                 'provider': a.provider,
                 'connected': True,
+                'daily_sending_limit': a.daily_sending_limit,
+                'current_daily_count': a.current_daily_count,
+                'warmup_enabled': a.warmup_enabled,
             }
             for a in deduped
         ]

--- a/backend/campaigns/migrations/0007_connectedemailaccount_warmup_limits.py
+++ b/backend/campaigns/migrations/0007_connectedemailaccount_warmup_limits.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0006_alter_sequencestep_channel_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='connectedemailaccount',
+            name='daily_sending_limit',
+            field=models.PositiveIntegerField(default=100),
+        ),
+        migrations.AddField(
+            model_name='connectedemailaccount',
+            name='current_daily_count',
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='connectedemailaccount',
+            name='warmup_enabled',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/campaigns/models.py
+++ b/backend/campaigns/models.py
@@ -22,6 +22,9 @@ class ConnectedEmailAccount(TenantModel):
     access_token = models.TextField()
     refresh_token = models.TextField(blank=True, null=True)
     token_expiry = models.DateTimeField(null=True, blank=True)
+    daily_sending_limit = models.PositiveIntegerField(default=100)
+    current_daily_count = models.PositiveIntegerField(default=0)
+    warmup_enabled = models.BooleanField(default=False)
 
     def __str__(self):
         return f"{self.email_address} ({self.get_provider_display()})"

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -3,14 +3,19 @@ from datetime import timedelta
 
 from celery import shared_task
 from django.conf import settings as django_settings
+from django.db import transaction
 from django.utils import timezone
 
 from .ai import personalize_email
 from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
 from .sms_service import send_sms, initiate_call
-from .models import CampaignLead, SequenceStep
+from .models import CampaignLead, ConnectedEmailAccount, SequenceStep
 
 logger = logging.getLogger(__name__)
+
+WARMUP_DAILY_INCREMENT = 5
+WARMUP_MAX_DAILY_LIMIT = 100
+RATE_LIMIT_RETRY_DELAY = timedelta(days=1)
 
 def _get_campaign_steps(campaign):
     """
@@ -383,6 +388,31 @@ def _execute_call_step(clead, step, now=None):
     _advance_to_next_step(clead, step, now=now)
 
 
+def _consume_connected_email_quota(account_id):
+    """
+    Reserve one send slot for the given connected email account.
+    Returns True when the quota was consumed, False when the daily limit was reached.
+    """
+    with transaction.atomic():
+        account = ConnectedEmailAccount._default_manager.select_for_update().get(id=account_id)
+
+        if account.daily_sending_limit <= 0:
+            return False
+
+        if account.current_daily_count >= account.daily_sending_limit:
+            return False
+
+        account.current_daily_count += 1
+        account.save(update_fields=['current_daily_count'])
+        return True
+
+
+def _reschedule_for_next_send_window(clead, now=None):
+    now = now or timezone.now()
+    clead.next_execution_time = now + RATE_LIMIT_RETRY_DELAY
+    clead.save(update_fields=['next_execution_time'])
+
+
 @shared_task
 def send_email_step(campaign_lead_id, step_id):
     """
@@ -424,6 +454,14 @@ def send_email_step(campaign_lead_id, step_id):
 
         account = clead.campaign.connected_account
         if account:
+            if not _consume_connected_email_quota(account.id):
+                logger.info(
+                    f"Daily send limit reached for {account.email_address}; "
+                    f"deferring {clead.lead.email} for warmup."
+                )
+                _reschedule_for_next_send_window(clead)
+                return
+
             try:
                 message_id = send_gmail(
                     account,
@@ -457,6 +495,42 @@ def process_active_leads():
     """
     processed = process_active_leads_once()
     return f"Triggered execution for {processed} campaign leads."
+
+
+@shared_task
+def refresh_connected_email_account_warmup_limits():
+    """
+    Daily reset for send quotas and warm-up progression.
+    Resets the current-day counter for every account and increases the daily
+    limit for warmup-enabled accounts.
+    """
+    accounts = ConnectedEmailAccount._default_manager.all().only(
+        'id',
+        'current_daily_count',
+        'daily_sending_limit',
+        'warmup_enabled',
+    )
+
+    updated = 0
+    for account in accounts:
+        updated_fields = []
+
+        if account.current_daily_count != 0:
+            account.current_daily_count = 0
+            updated_fields.append('current_daily_count')
+
+        if account.warmup_enabled and account.daily_sending_limit < WARMUP_MAX_DAILY_LIMIT:
+            account.daily_sending_limit = min(
+                account.daily_sending_limit + WARMUP_DAILY_INCREMENT,
+                WARMUP_MAX_DAILY_LIMIT,
+            )
+            updated_fields.append('daily_sending_limit')
+
+        if updated_fields:
+            account.save(update_fields=updated_fields)
+            updated += 1
+
+    return f"Refreshed warm-up limits for {updated} accounts."
 
 
 def process_active_leads_once(now=None):

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -12,6 +12,7 @@ from campaigns.tasks import (
     poll_gmail_for_replies,
     process_active_leads,
     process_active_leads_once,
+    refresh_connected_email_account_warmup_limits,
     send_email_step,
 )
 from campaigns.utils import generate_unsubscribe_token
@@ -558,6 +559,143 @@ class CampaignWorkflowTests(APITestCase):
         self.assertEqual(campaign_lead.status, 'ACTIVE')
         self.assertIsNone(campaign_lead.last_sent_message_id)
         self.assertGreater(campaign_lead.next_execution_time, timezone.now())
+
+    def test_send_email_step_defers_when_connected_account_hits_daily_limit(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Warmup limit flow',
+            status='ACTIVE',
+        )
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='limited@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+            daily_sending_limit=1,
+            current_daily_count=1,
+            warmup_enabled=True,
+        )
+        campaign.connected_account = account
+        campaign.save(update_fields=['connected_account'])
+
+        email_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='Warmup',
+            template_body='Hi there',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='warmup-blocked@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=email_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+
+        with patch('campaigns.tasks.send_gmail') as mocked_send:
+            send_email_step(campaign_lead.id, email_step.id)
+
+        campaign_lead.refresh_from_db()
+        account.refresh_from_db()
+        self.assertEqual(campaign_lead.current_step_id, email_step.id)
+        self.assertEqual(campaign_lead.status, 'ACTIVE')
+        self.assertIsNone(campaign_lead.last_sent_message_id)
+        self.assertGreater(campaign_lead.next_execution_time, timezone.now())
+        self.assertEqual(account.current_daily_count, 1)
+        mocked_send.assert_not_called()
+
+    def test_send_email_step_increments_daily_count_after_successful_send(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Warmup success flow',
+            status='ACTIVE',
+        )
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='sender@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+            daily_sending_limit=3,
+            current_daily_count=0,
+            warmup_enabled=True,
+        )
+        campaign.connected_account = account
+        campaign.save(update_fields=['connected_account'])
+
+        email_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='Hello',
+            template_body='Hi there',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='warmup-success@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=email_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+
+        with patch('campaigns.tasks.send_gmail', return_value='msg-abc'):
+            send_email_step(campaign_lead.id, email_step.id)
+
+        campaign_lead.refresh_from_db()
+        account.refresh_from_db()
+        self.assertEqual(campaign_lead.last_sent_message_id, 'msg-abc')
+        self.assertEqual(account.current_daily_count, 1)
+
+    def test_refresh_connected_email_account_warmup_limits_resets_counts_and_increments_limits(self):
+        warmup_account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='warmup@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+            daily_sending_limit=25,
+            current_daily_count=7,
+            warmup_enabled=True,
+        )
+        steady_account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='steady@acme.test',
+            provider='GOOGLE',
+            access_token='token2',
+            refresh_token='refresh2',
+            daily_sending_limit=60,
+            current_daily_count=19,
+            warmup_enabled=False,
+        )
+
+        refresh_connected_email_account_warmup_limits()
+
+        warmup_account.refresh_from_db()
+        steady_account.refresh_from_db()
+        self.assertEqual(warmup_account.current_daily_count, 0)
+        self.assertEqual(warmup_account.daily_sending_limit, 30)
+        self.assertEqual(steady_account.current_daily_count, 0)
+        self.assertEqual(steady_account.daily_sending_limit, 60)
 
     def test_condition_reply_step_stops_sequence_when_reply_detected(self):
         campaign = Campaign.objects.create(


### PR DESCRIPTION
Closes #118

## Summary
- adds `daily_sending_limit`, `current_daily_count`, and `warmup_enabled` to `ConnectedEmailAccount`
- enforces quota before Gmail sends and defers leads when the daily cap is reached
- resets daily counts and warms eligible accounts through a scheduled task
- seeds newly connected Gmail accounts with warmup enabled and a 25-email starting limit

## Validation
- `git diff --check`
- `python3 -m py_compile backend/campaigns/models.py backend/campaigns/tasks.py backend/campaigns/google_auth_views.py backend/campaigns/tests.py backend/backend/settings.py backend/campaigns/migrations/0007_connectedemailaccount_warmup_limits.py`
- `python manage.py test campaigns` (36 passed)
