### PR TITLE
feat: add lead engagement analytics

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1110,6 +1110,8 @@ class CampaignWorkflowTests(APITestCase):
         self.assertEqual(response.data['active_campaigns'], 0)
         self.assertEqual(response.data['emails_sent'], 0)
         self.assertEqual(response.data['replied'], 0)
+        self.assertEqual(response.data['tracked_leads'], 0)
+        self.assertEqual(response.data['engaged_leads'], 0)
         self.assertEqual(response.data['campaign_stats'], [])
 
         # org2 user should only see their own data
@@ -1119,6 +1121,40 @@ class CampaignWorkflowTests(APITestCase):
         self.assertEqual(response.data['total_leads'], 1)
         self.assertEqual(response.data['active_campaigns'], 1)
         self.assertEqual(response.data['replied'], 1)
+        self.assertEqual(response.data['tracked_leads'], 1)
+        self.assertEqual(response.data['engaged_leads'], 1)
+        self.assertTrue(response.data['recent_activity'])
+        self.assertIn('otherlead@othercorp.test', response.data['recent_activity'][0]['description'])
+
+    def test_dashboard_analytics_surfaces_engagement_tracking_summary(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Engagement Campaign',
+            status='ACTIVE',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='tracked@acme.test',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            status='REPLIED',
+            last_opened_at=timezone.now(),
+            last_clicked_at=timezone.now(),
+            last_replied_at=timezone.now(),
+        )
+
+        response = self.client.get('/api/v1/analytics/dashboard/?days=7')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['tracked_leads'], 1)
+        self.assertEqual(response.data['engaged_leads'], 1)
+        self.assertEqual(response.data['opened'], 1)
+        self.assertEqual(response.data['clicked'], 1)
+        self.assertEqual(response.data['replied'], 1)
+        self.assertTrue(response.data['recent_activity'])
+        self.assertIn('tracked@acme.test', response.data['recent_activity'][0]['description'])
 
     def test_dashboard_analytics_requires_authentication(self):
         self.client.force_authenticate(user=None)

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -306,6 +306,18 @@ class DashboardAnalyticsView(APIView):
         replied = all_cls.filter(status='REPLIED').count()
         clicked = all_cls.filter(last_clicked_at__isnull=False).count()
         bounced = all_cls.filter(status='BOUNCED').count()
+        tracked_leads = all_cls.filter(
+            Q(status__in=sent_statuses)
+            | Q(last_opened_at__isnull=False)
+            | Q(last_clicked_at__isnull=False)
+            | Q(last_replied_at__isnull=False)
+        ).values('lead_id').distinct().count()
+        engaged_leads = all_cls.filter(
+            Q(status='REPLIED')
+            | Q(last_opened_at__isnull=False)
+            | Q(last_clicked_at__isnull=False)
+            | Q(last_replied_at__isnull=False)
+        ).values('lead_id').distinct().count()
 
         total_leads = Lead.objects.filter(organization=org).count()
         active_campaigns = Campaign.objects.filter(organization=org, status='ACTIVE').count()
@@ -394,6 +406,8 @@ class DashboardAnalyticsView(APIView):
             'reply_rate': reply_rate,
             'click_rate': click_rate,
             'bounce_rate': bounce_rate,
+            'tracked_leads': tracked_leads,
+            'engaged_leads': engaged_leads,
             'time_series': {
                 'labels': labels,
                 'sent': sent_series,

--- a/frontend/leads.html
+++ b/frontend/leads.html
@@ -106,6 +106,51 @@
                     </div>
                 </div>
 
+                <div class="row g-4 mb-4">
+                    <div class="col-lg-6">
+                        <div class="glass-card p-3 h-100">
+                            <div class="d-flex flex-wrap align-items-start justify-content-between gap-2">
+                                <div>
+                                    <div class="section-title mb-1">Engagement Snapshot</div>
+                                    <div class="title-meta">Recent tracking activity across your campaigns.</div>
+                                </div>
+                                <span class="chip" style="background:#e0f2fe;color:#0369a1;">Last 30 days</span>
+                            </div>
+                            <div class="row g-3 mt-1">
+                                <div class="col-6 col-xl-3">
+                                    <div class="kpi-label">Tracked</div>
+                                    <div class="kpi-value" id="tracked-leads-count">0</div>
+                                    <div class="kpi-sub">Leads with campaign activity</div>
+                                </div>
+                                <div class="col-6 col-xl-3">
+                                    <div class="kpi-label">Engaged</div>
+                                    <div class="kpi-value" id="engaged-leads-count">0</div>
+                                    <div class="kpi-sub">Opened, clicked, or replied</div>
+                                </div>
+                                <div class="col-6 col-xl-3">
+                                    <div class="kpi-label">Open Rate</div>
+                                    <div class="kpi-value" id="lead-open-rate">0%</div>
+                                    <div class="kpi-sub">From tracked sends</div>
+                                </div>
+                                <div class="col-6 col-xl-3">
+                                    <div class="kpi-label">Reply Rate</div>
+                                    <div class="kpi-value" id="lead-reply-rate">0%</div>
+                                    <div class="kpi-sub">Direct responses</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-6">
+                        <div class="glass-card p-3 h-100">
+                            <div class="section-title mb-1">Recent Engagement</div>
+                            <div class="title-meta mb-3">Latest opens, clicks, replies, and delivery events.</div>
+                            <div id="lead-engagement-feed" class="list-group list-group-flush" style="max-height: 228px; overflow:auto;">
+                                <div class="text-muted small">Loading engagement activity...</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="table-shell">
                     <div class="table-responsive">
                         <table class="table table-hover mb-0 align-middle">
@@ -169,6 +214,7 @@
         import { fetchWithAuth } from '/api.js';
 
         let allLeads = [];
+        let analyticsSnapshot = null;
 
         function copyToClipboard(text, button) {
             navigator.clipboard.writeText(text).then(() => {
@@ -251,6 +297,47 @@
             document.getElementById('avg-score').textContent = avgScore;
         }
 
+        function renderEngagementSnapshot(snapshot) {
+            const data = snapshot || {};
+            document.getElementById('tracked-leads-count').textContent = data.tracked_leads || 0;
+            document.getElementById('engaged-leads-count').textContent = data.engaged_leads || 0;
+            document.getElementById('lead-open-rate').textContent = `${data.open_rate || 0}%`;
+            document.getElementById('lead-reply-rate').textContent = `${data.reply_rate || 0}%`;
+
+            const feed = document.getElementById('lead-engagement-feed');
+            const items = Array.isArray(data.recent_activity) ? data.recent_activity : [];
+            if (!items.length) {
+                feed.innerHTML = '<div class="text-muted small">No engagement events yet. Launch a campaign to start tracking activity.</div>';
+                return;
+            }
+
+            feed.innerHTML = items.map(item => {
+                const type = (item.type || '').replace('lead_', '').toUpperCase();
+                const tone = {
+                    OPEN: 'background:#dcfce7;color:#166534;',
+                    CLICK: 'background:#dbeafe;color:#1d4ed8;',
+                    REPLIED: 'background:#fef3c7;color:#92400e;',
+                    BOUNCED: 'background:#fee2e2;color:#b91c1c;',
+                    ACTIVE: 'background:#e2e8f0;color:#334155;',
+                    FINISHED: 'background:#e2e8f0;color:#334155;',
+                    ENROLLED: 'background:#e2e8f0;color:#334155;',
+                    PAUSED: 'background:#e2e8f0;color:#334155;',
+                }[type] || 'background:#e2e8f0;color:#334155;';
+                const time = item.time ? new Date(item.time).toLocaleString() : 'Just now';
+                return `
+                    <div class="list-group-item px-0 py-2 border-0 border-bottom">
+                        <div class="d-flex flex-wrap align-items-start justify-content-between gap-2">
+                            <div>
+                                <div class="fw-semibold small">${item.description || 'Unknown activity'}</div>
+                                <div class="text-muted small">${time}</div>
+                            </div>
+                            <span class="chip" style="${tone}">${type || 'EVENT'}</span>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+        }
+
         function applySearch() {
             const q = (document.getElementById('lead-search').value || '').trim().toLowerCase();
             if (!q) {
@@ -266,14 +353,26 @@
 
         document.addEventListener('DOMContentLoaded', async () => {
             try {
-                const res = await fetchWithAuth('/leads/');
-                if (res.ok) {
-                    allLeads = await res.json();
+                const [leadsRes, analyticsRes] = await Promise.all([
+                    fetchWithAuth('/leads/'),
+                    fetchWithAuth('/analytics/dashboard/?days=30'),
+                ]);
+
+                if (leadsRes.ok) {
+                    allLeads = await leadsRes.json();
                     renderStats(allLeads);
                     renderLeadRows(allLeads);
                 }
+
+                if (analyticsRes.ok) {
+                    analyticsSnapshot = await analyticsRes.json();
+                    renderEngagementSnapshot(analyticsSnapshot);
+                } else {
+                    renderEngagementSnapshot(null);
+                }
             } catch (e) {
                 console.error('Error fetching leads:', e);
+                renderEngagementSnapshot(null);
             }
 
             document.getElementById('lead-search').addEventListener('input', applySearch);


### PR DESCRIPTION
Closes #134

## Summary
- adds `tracked_leads` and `engaged_leads` to the analytics dashboard payload
- renders a Leads-page engagement snapshot with tracked, engaged, open-rate, and reply-rate metrics
- adds a recent engagement feed so the Leads page shows actual tracking activity instead of just static lead rows

## Validation
- `git diff --check`
- `node --check` on the extracted Leads-page module script
- `curl` confirmed the new Leads-page section is served
- `python manage.py test campaigns` (34 passed)
