### PR TITLE
feat: add lead search and tag filters

### DIFF
--- a/backend/leads/serializers.py
+++ b/backend/leads/serializers.py
@@ -15,5 +15,9 @@ class LeadSerializer(serializers.ModelSerializer):
         read_only_fields = ['organization', 'score']
 
     def get_tags(self, obj):
+        if hasattr(obj, 'lead_tags'):
+            tags = [lead_tag.tag for lead_tag in obj.lead_tags.all() if getattr(lead_tag, 'tag', None)]
+            return TagSerializer(tags, many=True).data
+
         tags = Tag.objects.filter(tagged_leads__lead=obj)
         return TagSerializer(tags, many=True).data

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from leads.models import Lead
+from leads.models import Lead, LeadTag, Tag
 from leads.tasks import import_leads_from_csv
 from tenants.models import Organization
 from users.models import User
@@ -88,3 +88,71 @@ class LeadIsolationAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(Lead.objects.filter(id=self.lead_a.id).exists())
         self.assertTrue(Lead.objects.filter(id=self.lead_b.id).exists())
+
+    def test_list_leads_supports_search_across_core_fields(self):
+        search_lead = Lead.objects.create(
+            organization=self.org_a,
+            email='alice@example.com',
+            first_name='Alice',
+            last_name='Stone',
+            company='Acme Labs',
+        )
+        Lead.objects.create(
+            organization=self.org_b,
+            email='alice@other-org.com',
+            first_name='Alice',
+            last_name='Stone',
+            company='Acme Labs',
+        )
+
+        self.client.force_authenticate(self.user_a)
+
+        for query in ['alice', 'stone', 'acme', 'alice@example.com']:
+            with self.subTest(query=query):
+                response = self.client.get('/api/v1/leads/', {'search': query})
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                emails = {item['email'] for item in response.data}
+                self.assertIn(search_lead.email, emails)
+                self.assertNotIn('alice@other-org.com', emails)
+
+    def test_list_leads_supports_tag_filtering_with_tenant_isolation(self):
+        vip_tag = Tag.objects.create(
+            organization=self.org_a,
+            name='VIP',
+        )
+        LeadTag.objects.create(
+            organization=self.org_a,
+            lead=self.lead_a,
+            tag=vip_tag,
+        )
+        lead_without_tag = Lead.objects.create(
+            organization=self.org_a,
+            email='untagged@example.com',
+            first_name='No',
+            last_name='Tag',
+        )
+
+        org_b_tag = Tag.objects.create(
+            organization=self.org_b,
+            name='VIP',
+        )
+        Lead.objects.create(
+            organization=self.org_b,
+            email='other-org-vip@example.com',
+            first_name='Other',
+            last_name='Org',
+        )
+        LeadTag.objects.create(
+            organization=self.org_b,
+            lead=self.lead_b,
+            tag=org_b_tag,
+        )
+
+        self.client.force_authenticate(self.user_a)
+        response = self.client.get('/api/v1/leads/', {'tag': str(vip_tag.id)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        emails = {item['email'] for item in response.data}
+        self.assertIn(self.lead_a.email, emails)
+        self.assertNotIn(lead_without_tag.email, emails)
+        self.assertNotIn('other-org-vip@example.com', emails)

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -1,3 +1,6 @@
+from uuid import UUID
+
+from django.db.models import Q
 from rest_framework import viewsets, parsers, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -11,6 +14,70 @@ class LeadViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         # Do not rely only on thread-local tenant middleware for JWT requests.
         return Lead.objects.filter(organization=self.request.user.organization)
+
+    def _matches_search(self, lead, search_value):
+        normalized = search_value.strip().casefold()
+        searchable_values = [
+            lead.email,
+            lead.first_name,
+            lead.last_name,
+            lead.company,
+        ]
+        return any(
+            normalized in str(value or '').casefold()
+            for value in searchable_values
+        )
+
+    def _filter_by_tag(self, queryset, tag_value):
+        value = (tag_value or '').strip()
+        if not value:
+            return queryset
+
+        tag_tokens = [token.strip() for token in value.split(',') if token.strip()]
+        if not tag_tokens:
+            return queryset
+
+        tag_ids = []
+        tag_names = []
+        for token in tag_tokens:
+            try:
+                tag_ids.append(UUID(token))
+                continue
+            except (TypeError, ValueError):
+                pass
+            tag_names.append(token)
+
+        tag_filter = Q()
+        has_filter = False
+        if tag_ids:
+            tag_filter |= Q(lead_tags__tag__id__in=tag_ids)
+            has_filter = True
+        if tag_names:
+            name_filter = Q()
+            for token in tag_names:
+                name_filter |= Q(lead_tags__tag__name__iexact=token)
+            tag_filter |= name_filter
+            has_filter = True
+
+        if not has_filter:
+            return queryset
+
+        return queryset.filter(tag_filter).distinct()
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset().prefetch_related('lead_tags__tag')
+
+        tag_value = request.query_params.get('tag') or request.query_params.get('tag_id') or ''
+        search_value = request.query_params.get('search') or request.query_params.get('q') or ''
+
+        queryset = self._filter_by_tag(queryset, tag_value)
+        leads = list(queryset)
+
+        if search_value.strip():
+            leads = [lead for lead in leads if self._matches_search(lead, search_value)]
+
+        serializer = self.get_serializer(leads, many=True)
+        return Response(serializer.data)
 
     def perform_create(self, serializer):
         serializer.save(organization=self.request.user.organization)
@@ -28,14 +95,14 @@ class LeadViewSet(viewsets.ModelViewSet):
         file_obj = request.FILES.get('file')
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
-        
+
         # Trigger async celery task
         from .tasks import import_leads_from_csv
         file_contents = file_obj.read().decode('utf-8')
-        
+
         # Ensure we pass the organization to the task
         import_leads_from_csv.delay(file_contents, request.user.organization.id)
-        
+
         return Response({"message": "File received. Processing in background.", "filename": file_obj.name}, status=status.HTTP_202_ACCEPTED)
 
 class TagViewSet(viewsets.ModelViewSet):

--- a/frontend/leads.html
+++ b/frontend/leads.html
@@ -62,11 +62,17 @@
                         <div class="title-meta">Upload, review, and segment leads for campaign enrollment.</div>
                     </div>
                     <div class="d-flex align-items-center gap-2">
-                        <div class="search-wrap">
+                        <div class="search-wrap d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2">
                             <div class="input-group input-group-sm">
                                 <span class="input-group-text"><i class="bi bi-search"></i></span>
                                 <input type="text" id="lead-search" class="form-control" placeholder="Search name, email, company">
                             </div>
+                            <select id="tag-filter" class="form-select form-select-sm">
+                                <option value="">All tags</option>
+                            </select>
+                            <button id="clear-filters-btn" type="button" class="btn btn-sm btn-outline-secondary">
+                                Clear
+                            </button>
                         </div>
                         <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#uploadModal">
                             <i class="bi bi-upload me-1"></i> Import CSV
@@ -115,6 +121,7 @@
                                     <th>Email</th>
                                     <th>Phone</th>
                                     <th>Company</th>
+                                    <th>Tags</th>
                                     <th>Score</th>
                                     <th>Status</th>
                                 </tr>
@@ -168,7 +175,23 @@
     <script type="module">
         import { fetchWithAuth } from '/api.js';
 
-        let allLeads = [];
+        const state = {
+            search: '',
+            tag: '',
+        };
+
+        let refreshTimer = null;
+        let allTags = [];
+
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, (char) => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+            })[char]);
+        }
 
         function copyToClipboard(text, button) {
             navigator.clipboard.writeText(text).then(() => {
@@ -184,99 +207,173 @@
             });
         }
 
-        function renderLeadRows(leads) {
-            const tbody = document.getElementById('leads-table-body');
-            if (leads.length === 0) {
-             tbody.innerHTML = `
-<tr>
-    <td colspan="6" class="text-center py-5">
-        <div class="empty-state">
-            <i class="bi bi-people display-4 text-secondary"></i>
-
-            <h5 class="mt-3 mb-2">
-                No leads yet
-            </h5>
-
-            <p class="text-muted mb-3">
-                Import your first CSV to get started!
-            </p>
-
-            <button
-                class="btn btn-primary btn-sm"
-                data-bs-toggle="modal"
-                data-bs-target="#uploadModal">
-                <i class="bi bi-upload me-1"></i>
-                Import CSV
-            </button>
-        </div>
-    </td>
-</tr>`;
-                return;
-            }
-
-            tbody.innerHTML = leads.map(lead => `
+        function setLoadingState() {
+            document.getElementById('leads-table-body').innerHTML = `
                 <tr>
-                    <td class="fw-semibold">${lead.first_name || ''} ${lead.last_name || ''}</td>
-                    <td>
-                        <span>${lead.email}</span>
-                        <button
-                            class="btn btn-sm btn-outline-secondary copy-email-btn"
-                            data-email="${lead.email}">
-                            <i class="bi bi-clipboard"></i>
-                        </button>
+                    <td colspan="7" class="text-center py-4 text-muted">
+                        <div class="spinner-border spinner-border-sm text-primary me-2" role="status"></div>
+                        Loading leads...
                     </td>
-                    <td>${lead.phone || '<span class="text-muted">-</span>'}</td>
-                    <td>${lead.company || '<span class="text-muted">-</span>'}</td>
-                    <td><span class="chip" style="background:#e0f2fe;color:#0369a1;">${lead.score}</span></td>
-                    <td>${lead.global_unsubscribe
-                        ? '<span class="chip" style="background:#fee2e2;color:#b91c1c;">Unsubscribed</span>'
-                        : '<span class="chip" style="background:#dcfce7;color:#166534;">Active</span>'}</td>
-                </tr>
-            `).join('');
+                </tr>`;
+        }
 
-            document.querySelectorAll('.copy-email-btn').forEach(btn => {
-                btn.addEventListener('click', () => {
-                    copyToClipboard(btn.dataset.email, btn);
-                });
-            });
-            
+        function renderTagOptions(tags) {
+            const select = document.getElementById('tag-filter');
+            select.innerHTML = ['<option value="">All tags</option>']
+                .concat(tags.map((tag) => `<option value="${escapeHtml(tag.id)}">${escapeHtml(tag.name)}</option>`))
+                .join('');
+            select.value = state.tag;
         }
 
         function renderStats(leads) {
             document.getElementById('leads-count').textContent = leads.length;
-            const active = leads.filter(l => !l.global_unsubscribe).length;
+            const active = leads.filter((l) => !l.global_unsubscribe).length;
             document.getElementById('active-leads-count').textContent = active;
             document.getElementById('unsubscribed-count').textContent = leads.length - active;
             const avgScore = leads.length ? (leads.reduce((sum, l) => sum + Number(l.score || 0), 0) / leads.length).toFixed(1) : '0.0';
             document.getElementById('avg-score').textContent = avgScore;
         }
 
-        function applySearch() {
-            const q = (document.getElementById('lead-search').value || '').trim().toLowerCase();
-            if (!q) {
-                renderLeadRows(allLeads);
+        function renderLeadRows(leads) {
+            const tbody = document.getElementById('leads-table-body');
+            const hasFilters = Boolean(state.search || state.tag);
+
+            if (leads.length === 0) {
+                tbody.innerHTML = `
+                    <tr>
+                        <td colspan="7" class="text-center py-5">
+                            <div class="empty-state">
+                                <i class="bi bi-people display-4 text-secondary"></i>
+                                <h5 class="mt-3 mb-2">${hasFilters ? 'No results found' : 'No leads yet'}</h5>
+                                <p class="text-muted mb-3">
+                                    ${hasFilters
+                                        ? 'Try clearing the search or tag filter.'
+                                        : 'Import your first CSV to get started!'}
+                                </p>
+                                <div class="d-flex justify-content-center gap-2">
+                                    ${hasFilters ? '<button class="btn btn-outline-secondary btn-sm" id="clear-empty-filters-btn"><i class="bi bi-x-circle me-1"></i>Clear filters</button>' : ''}
+                                    <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#uploadModal">
+                                        <i class="bi bi-upload me-1"></i>
+                                        Import CSV
+                                    </button>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>`;
+
+                const clearBtn = document.getElementById('clear-empty-filters-btn');
+                if (clearBtn) {
+                    clearBtn.addEventListener('click', clearFilters);
+                }
                 return;
             }
-            const filtered = allLeads.filter(lead => {
-                const row = `${lead.first_name || ''} ${lead.last_name || ''} ${lead.email || ''} ${lead.company || ''}`.toLowerCase();
-                return row.includes(q);
+
+            tbody.innerHTML = leads.map((lead) => {
+                const tags = Array.isArray(lead.tags) ? lead.tags : [];
+                return `
+                    <tr>
+                        <td class="fw-semibold">${escapeHtml(`${lead.first_name || ''} ${lead.last_name || ''}`.trim())}</td>
+                        <td>
+                            <span>${escapeHtml(lead.email)}</span>
+                            <button
+                                class="btn btn-sm btn-outline-secondary copy-email-btn"
+                                data-email="${escapeHtml(lead.email)}">
+                                <i class="bi bi-clipboard"></i>
+                            </button>
+                        </td>
+                        <td>${lead.phone ? escapeHtml(lead.phone) : '<span class="text-muted">-</span>'}</td>
+                        <td>${lead.company ? escapeHtml(lead.company) : '<span class="text-muted">-</span>'}</td>
+                        <td>
+                            ${tags.length
+                                ? tags.map((tag) => `<span class="chip me-1 mb-1" style="background:#f1f5f9;color:#0f172a;">${escapeHtml(tag.name)}</span>`).join('')
+                                : '<span class="text-muted">-</span>'}
+                        </td>
+                        <td><span class="chip" style="background:#e0f2fe;color:#0369a1;">${escapeHtml(lead.score)}</span></td>
+                        <td>${lead.global_unsubscribe
+                            ? '<span class="chip" style="background:#fee2e2;color:#b91c1c;">Unsubscribed</span>'
+                            : '<span class="chip" style="background:#dcfce7;color:#166534;">Active</span>'}</td>
+                    </tr>`;
+            }).join('');
+
+            document.querySelectorAll('.copy-email-btn').forEach((btn) => {
+                btn.addEventListener('click', () => {
+                    copyToClipboard(btn.dataset.email, btn);
+                });
             });
-            renderLeadRows(filtered);
+        }
+
+        function clearFilters() {
+            state.search = '';
+            state.tag = '';
+            document.getElementById('lead-search').value = '';
+            document.getElementById('tag-filter').value = '';
+            fetchLeads();
+        }
+
+        async function fetchTags() {
+            try {
+                const res = await fetchWithAuth('/tags/');
+                if (!res.ok) {
+                    return;
+                }
+
+                allTags = await res.json();
+                allTags.sort((a, b) => a.name.localeCompare(b.name));
+                renderTagOptions(allTags);
+            } catch (error) {
+                console.error('Error fetching tags:', error);
+            }
+        }
+
+        async function fetchLeads() {
+            setLoadingState();
+
+            const params = new URLSearchParams();
+            if (state.search) {
+                params.set('search', state.search);
+            }
+            if (state.tag) {
+                params.set('tag', state.tag);
+            }
+
+            const url = params.toString() ? `/leads/?${params.toString()}` : '/leads/';
+
+            try {
+                const res = await fetchWithAuth(url);
+                if (!res.ok) {
+                    throw new Error(`Failed to load leads (${res.status})`);
+                }
+
+                const leads = await res.json();
+                renderStats(leads);
+                renderLeadRows(leads);
+            } catch (error) {
+                console.error('Error fetching leads:', error);
+                document.getElementById('leads-table-body').innerHTML = `
+                    <tr>
+                        <td colspan="7" class="text-center py-5 text-danger">
+                            <i class="bi bi-exclamation-triangle me-1"></i>
+                            Unable to load leads.
+                        </td>
+                    </tr>`;
+            }
+        }
+
+        function scheduleFetch() {
+            clearTimeout(refreshTimer);
+            refreshTimer = setTimeout(() => {
+                state.search = document.getElementById('lead-search').value.trim();
+                state.tag = document.getElementById('tag-filter').value;
+                fetchLeads();
+            }, 300);
         }
 
         document.addEventListener('DOMContentLoaded', async () => {
-            try {
-                const res = await fetchWithAuth('/leads/');
-                if (res.ok) {
-                    allLeads = await res.json();
-                    renderStats(allLeads);
-                    renderLeadRows(allLeads);
-                }
-            } catch (e) {
-                console.error('Error fetching leads:', e);
-            }
+            await Promise.all([fetchTags(), fetchLeads()]);
 
-            document.getElementById('lead-search').addEventListener('input', applySearch);
+            document.getElementById('lead-search').addEventListener('input', scheduleFetch);
+            document.getElementById('tag-filter').addEventListener('change', scheduleFetch);
+            document.getElementById('clear-filters-btn').addEventListener('click', clearFilters);
 
             document.getElementById('upload-form').addEventListener('submit', async (e) => {
                 e.preventDefault();


### PR DESCRIPTION
Closes #33

## Summary
- adds server-side lead search across email, first name, last name, and company
- adds tag-based filtering while preserving tenant isolation
- updates the Leads page with debounced search, tag dropdown filters, and empty-result handling
- shows lead tags in the table for easier scanning

## Validation
- `git diff --check`
- `node --check` on the extracted `frontend/leads.html` module script
- `python manage.py test leads` (6 passed)
