### PR TITLE
feat: add tooltip help text to dashboard KPI cards

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -91,22 +91,42 @@
             <section class="content-wrap">
                 <div class="kpi-grid mb-4">
                     <div class="kpi-card">
-                        <div class="kpi-label">Total Leads</div>
+                        <div class="kpi-label">
+                        Total Leads
+                        <i class="bi bi-info-circle text-muted ms-1"
+                        data-bs-toggle="tooltip"
+                        data-bs-title="The total number of lead contacts imported into your workspace."></i>
+                    </div>
                         <div class="kpi-value"><div class="skeleton-box skeleton-kpi-value skeleton-kpi"></div><span id="total-leads-count" class="kpi-value-text" style="display: none;">0</span></div>
                         <div class="kpi-sub">Prospects in your workspace</div>
                     </div>
                     <div class="kpi-card">
-                        <div class="kpi-label">Active Campaigns</div>
+                        <div class="kpi-label">
+                            Active Campaigns
+                            <i class="bi bi-info-circle text-muted ms-1"
+                            data-bs-toggle="tooltip"
+                            data-bs-title="Campaigns currently sending emails or processing sequence steps."></i>
+                        </div>
                         <div class="kpi-value"><div class="skeleton-box skeleton-kpi-value skeleton-kpi"></div><span id="active-campaigns-count" class="kpi-value-text" style="display: none;">0</span></div>
                         <div class="kpi-sub">Currently running sequences</div>
                     </div>
                     <div class="kpi-card">
-                        <div class="kpi-label">Emails Sent</div>
+                        <div class="kpi-label">
+                            Emails Sent
+                            <i class="bi bi-info-circle text-muted ms-1"
+                            data-bs-toggle="tooltip"
+                            data-bs-title="Total outbound emails delivered across all campaigns."></i>
+                        </div>
                         <div class="kpi-value"><div class="skeleton-box skeleton-kpi-value skeleton-kpi"></div><span id="emails-sent-count" class="kpi-value-text" style="display: none;">0</span></div>
                         <div class="kpi-sub">Messages delivered by campaigns</div>
                     </div>
                     <div class="kpi-card">
-                        <div class="kpi-label">Reply Rate</div>
+                        <div class="kpi-label">
+                            Reply Rate
+                            <i class="bi bi-info-circle text-muted ms-1"
+                            data-bs-toggle="tooltip"
+                            data-bs-title="Percentage of contacted leads who replied to your outreach."></i>
+                        </div>
                         <div class="kpi-value text-success"><div class="skeleton-box skeleton-kpi-value skeleton-kpi"></div><span id="reply-rate" class="kpi-value-text" style="display: none;">0.0%</span></div>
                         <div class="kpi-sub">Percentage of leads replying</div>
                     </div>
@@ -217,6 +237,12 @@
         });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+        [...tooltipTriggerList].forEach(el => new bootstrap.Tooltip(el));
+    });
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Added Bootstrap tooltip help text to Dashboard KPI cards to improve clarity and help users understand dashboard metrics at a glance.

## Changes Made

- Added info icons beside KPI labels on the Dashboard.
- Implemented Bootstrap tooltips for all KPI cards.
- Added descriptive help text for each metric.
- Initialized tooltips using Bootstrap JavaScript.
- Kept the UI clean and consistent with existing dashboard styling.

### KPI Tooltips Added

| KPI Label | Tooltip Text |
|------------|-------------|
| Total Leads | The total number of lead contacts imported into your workspace. |
| Active Campaigns | Campaigns currently sending emails or processing sequence steps. |
| Emails Sent | Total outbound emails delivered across all campaigns. |
| Reply Rate | Percentage of contacted leads who replied to your outreach. |

## Files Modified

- `frontend/dashboard.html`

## Screenshots

### 1. Total Leads Tooltip
Shows explanatory tooltip for Total Leads KPI.

<img width="1907" height="808" alt="Screenshot 2026-06-10 232600" src="https://github.com/user-attachments/assets/7292679c-b068-4bca-a3bb-8aed2ec08215" />


### 2. Active Campaigns Tooltip
Shows explanatory tooltip for Active Campaigns KPI.

<img width="1918" height="803" alt="Screenshot 2026-06-10 232612" src="https://github.com/user-attachments/assets/5a4cb36a-9ed4-422d-ae28-489aeb513150" />


### 3. Emails Sent Tooltip
Shows explanatory tooltip for Emails Sent KPI.

<img width="1912" height="828" alt="Screenshot 2026-06-10 232626" src="https://github.com/user-attachments/assets/ff857e07-2d03-435c-a6ca-fdfd8a028bbb" />


### 4. Reply Rate Tooltip
Shows explanatory tooltip for Reply Rate KPI.

<img width="1915" height="817" alt="Screenshot 2026-06-10 232637" src="https://github.com/user-attachments/assets/9cfd538b-e3fd-40b2-a65d-30bfcd9037e7" />

## Testing Performed

- Tested tooltip visibility on all KPI cards.
- Verified correct tooltip text is displayed on hover.
- Confirmed UI layout is unaffected.
- No console errors found.

Closes #57 

