### PR TITLE
fix: sign Google OAuth state payload

### DIFF
--- a/backend/campaigns/google_auth_views.py
+++ b/backend/campaigns/google_auth_views.py
@@ -8,11 +8,11 @@ Architecture notes:
   base model and explicit org assignment, since the callback request is
   unauthenticated (Google redirect).
 """
-import json
 import logging
 import requests
 from urllib.parse import urlencode, urlparse
 
+from django.core import signing
 from django.conf import settings
 from django.shortcuts import redirect
 from django.utils import timezone
@@ -27,6 +27,9 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from .models import ConnectedEmailAccount
 
 logger = logging.getLogger(__name__)
+
+GOOGLE_OAUTH_STATE_SALT = 'leadorbit-google-oauth-state'
+GOOGLE_OAUTH_STATE_MAX_AGE_SECONDS = 10 * 60
 
 
 def _is_local_host(hostname: str) -> bool:
@@ -103,11 +106,11 @@ class GoogleOAuthLoginView(APIView):
 
         # Encode user identity in state so callback can link to correct user
         frontend_origin = _sanitize_frontend_base(request, request.GET.get('frontend_origin', ''))
-        state_data = json.dumps({
+        state_data = signing.dumps({
             'user_id': str(user.id),
             'org_id': str(user.organization_id),
             'frontend_origin': frontend_origin,
-        })
+        }, salt=GOOGLE_OAUTH_STATE_SALT)
 
         params = {
             'client_id': settings.GOOGLE_CLIENT_ID,
@@ -139,9 +142,13 @@ class GoogleOAuthCallbackView(APIView):
         frontend_origin = ''
         if state_raw:
             try:
-                state_data = json.loads(state_raw)
+                state_data = signing.loads(
+                    state_raw,
+                    salt=GOOGLE_OAUTH_STATE_SALT,
+                    max_age=GOOGLE_OAUTH_STATE_MAX_AGE_SECONDS,
+                )
                 frontend_origin = _sanitize_frontend_base(request, state_data.get('frontend_origin', ''))
-            except (json.JSONDecodeError, TypeError):
+            except (signing.BadSignature, signing.SignatureExpired, TypeError):
                 frontend_origin = ''
 
         oauth_error = request.GET.get('error')
@@ -175,7 +182,11 @@ class GoogleOAuthCallbackView(APIView):
 
         if state_raw:
             try:
-                state_data = json.loads(state_raw)
+                state_data = signing.loads(
+                    state_raw,
+                    salt=GOOGLE_OAUTH_STATE_SALT,
+                    max_age=GOOGLE_OAUTH_STATE_MAX_AGE_SECONDS,
+                )
                 user_id = state_data.get('user_id')
                 org_id = state_data.get('org_id')
                 frontend_origin = _sanitize_frontend_base(request, state_data.get('frontend_origin', ''))
@@ -188,7 +199,7 @@ class GoogleOAuthCallbackView(APIView):
                     logger.info(f"[OAuth Callback] Resolved user={user.email}, org={org.name}")
                 except (User.DoesNotExist, Organization.DoesNotExist) as e:
                     logger.warning(f"[OAuth Callback] Could not find user/org from state: {e}")
-            except (json.JSONDecodeError, KeyError, TypeError) as e:
+            except (signing.BadSignature, signing.SignatureExpired, KeyError, TypeError) as e:
                 logger.warning(f"[OAuth Callback] Failed to parse state parameter: {e}")
 
         if not user or not org:

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
+from django.core import signing
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status
@@ -1287,3 +1289,88 @@ class CampaignWorkflowTests(APITestCase):
         self.assertIsNone(campaign_lead.next_execution_time)
         self.assertEqual(campaign.status, 'COMPLETED')
         mocked_send.assert_not_called()
+
+
+@override_settings(
+    GOOGLE_CLIENT_ID='test-google-client-id',
+    GOOGLE_CLIENT_SECRET='test-google-client-secret',
+    GOOGLE_REDIRECT_URI='https://example.test/api/v1/auth/google/callback',
+    GOOGLE_SCOPES=['https://www.googleapis.com/auth/gmail.send'],
+)
+class GoogleOAuthStateTests(APITestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name='OAuth Org')
+        self.user = User.objects.create_user(
+            email='oauth-owner@acme.test',
+            password='StrongPass123!',
+            organization=self.organization,
+            role='ADMIN',
+        )
+        self.client.force_authenticate(self.user)
+
+    def test_login_view_signs_oauth_state(self):
+        response = self.client.get(
+            '/api/v1/auth/google/login',
+            {'frontend_origin': 'https://app.example.test'},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        redirect_url = response['Location']
+        parsed = urlparse(redirect_url)
+        params = parse_qs(parsed.query)
+        state = params['state'][0]
+
+        state_data = signing.loads(
+            state,
+            salt='leadorbit-google-oauth-state',
+            max_age=600,
+        )
+        self.assertEqual(state_data['user_id'], str(self.user.id))
+        self.assertEqual(state_data['org_id'], str(self.organization.id))
+        self.assertEqual(state_data['frontend_origin'], 'https://app.example.test')
+
+    def test_callback_rejects_tampered_state_and_accepts_signed_state(self):
+        with patch('campaigns.google_auth_views.requests.post') as mock_post, patch(
+            'campaigns.google_auth_views.requests.get'
+        ) as mock_get:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = {
+                'access_token': 'access-token',
+                'refresh_token': 'refresh-token',
+                'expires_in': 3600,
+            }
+            mock_get.return_value.json.return_value = {'email': 'sender@example.test'}
+
+            signed_state = signing.dumps(
+                {
+                    'user_id': str(self.user.id),
+                    'org_id': str(self.organization.id),
+                    'frontend_origin': 'https://app.example.test',
+                },
+                salt='leadorbit-google-oauth-state',
+            )
+            response = self.client.get(
+                '/api/v1/auth/google/callback',
+                {'code': 'authorization-code', 'state': signed_state},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn('google_auth=connected', response['Location'])
+        self.assertTrue(
+            ConnectedEmailAccount.objects.filter(
+                organization=self.organization,
+                connected_by=self.user,
+                provider='GOOGLE',
+                email_address='sender@example.test',
+            ).exists()
+        )
+
+        tampered_state = signed_state[:-1] + ('x' if signed_state[-1] != 'x' else 'y')
+        response = self.client.get(
+            '/api/v1/auth/google/callback',
+            {'code': 'authorization-code', 'state': tampered_state},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn('google_auth=error', response['Location'])
+        self.assertIn('reason=no_user', response['Location'])


### PR DESCRIPTION
Closes #222

## Summary
- signs the Google OAuth `state` payload before redirecting to Google
- rejects tampered or expired `state` values in the callback instead of trusting raw JSON
- keeps the frontend origin, user ID, and org ID flow intact while closing the state-tampering gap

## Validation
- `git diff --check`
- `python3 manage.py test campaigns.tests.GoogleOAuthStateTests`
