### PR TITLE
feat: store bounce metadata from webhooks

### DIFF
--- a/backend/campaigns/migrations/0009_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0009_campaignlead_bounce_metadata.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("campaigns", "0008_merge_20260610_2213"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="campaignlead",
+            name="bounce_code",
+            field=models.CharField(blank=True, max_length=64, null=True),
+        ),
+        migrations.AddField(
+            model_name="campaignlead",
+            name="bounce_reason",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="campaignlead",
+            name="bounce_type",
+            field=models.CharField(blank=True, max_length=32, null=True),
+        ),
+    ]

--- a/backend/campaigns/models.py
+++ b/backend/campaigns/models.py
@@ -99,6 +99,9 @@ class CampaignLead(TenantModel):
     last_opened_at = models.DateTimeField(null=True, blank=True)
     last_clicked_at = models.DateTimeField(null=True, blank=True)
     last_replied_at = models.DateTimeField(null=True, blank=True)
+    bounce_type = models.CharField(max_length=32, null=True, blank=True)
+    bounce_code = models.CharField(max_length=64, null=True, blank=True)
+    bounce_reason = models.TextField(null=True, blank=True)
 
     class Meta:
         unique_together = ('campaign', 'lead')

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1114,6 +1114,46 @@ class CampaignWorkflowTests(APITestCase):
             any('Webhook processing error for event=open email=lead@acme.test' in entry for entry in logs.output)
         )
 
+    def test_email_webhook_persists_bounce_metadata(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Bounce metadata flow',
+            status='ACTIVE',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='bounce@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            status='ACTIVE',
+            last_sent_message_id='msg-123',
+        )
+
+        response = self.client.post(
+            '/api/v1/webhooks/email/',
+            {
+                'event': 'bounce',
+                'email': 'bounce@acme.test',
+                'message_id': 'msg-123',
+                'bounce': {
+                    'type': 'soft',
+                    'code': 'mailbox_full',
+                    'reason': 'Mailbox full',
+                },
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        campaign_lead.refresh_from_db()
+        self.assertEqual(campaign_lead.status, 'BOUNCED')
+        self.assertEqual(campaign_lead.bounce_type, 'soft')
+        self.assertEqual(campaign_lead.bounce_code, 'mailbox_full')
+        self.assertEqual(campaign_lead.bounce_reason, 'Mailbox full')
+
     def test_dashboard_analytics_isolates_data_by_tenant(self):
         org2 = Organization.objects.create(name='Other Corp')
         other_user = User.objects.create_user(

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -226,11 +226,48 @@ class WebhookView(APIView):
     to track opens, clicks, bounces.
     """
     permission_classes = [AllowAny] # Webhooks need to be publicly accessible
+
+    @staticmethod
+    def _extract_bounce_details(payload):
+        bounce_payload = payload.get('bounce')
+        if not isinstance(bounce_payload, dict):
+            bounce_payload = {}
+
+        bounce_type = (
+            payload.get('bounce_type')
+            or bounce_payload.get('type')
+            or bounce_payload.get('bounce_type')
+            or payload.get('type')
+            or ''
+        )
+        bounce_code = (
+            payload.get('code')
+            or bounce_payload.get('code')
+            or bounce_payload.get('smtp_code')
+            or bounce_payload.get('status')
+            or ''
+        )
+        bounce_reason = (
+            payload.get('reason')
+            or payload.get('description')
+            or bounce_payload.get('reason')
+            or bounce_payload.get('description')
+            or bounce_payload.get('detail')
+            or payload.get('message')
+            or ''
+        )
+
+        return {
+            'bounce_type': str(bounce_type).strip().lower() or None,
+            'bounce_code': str(bounce_code).strip() or None,
+            'bounce_reason': str(bounce_reason).strip() or None,
+        }
     
     def post(self, request, *args, **kwargs):
         event_type = (request.data.get('event') or '').strip().lower()
         lead_email = request.data.get('email')
         message_id = request.data.get('message_id') or request.data.get('messageId')
+        bounce_details = self._extract_bounce_details(request.data)
         
         # Simple MVP tracking
         if event_type and lead_email:
@@ -255,7 +292,25 @@ class WebhookView(APIView):
                 for cl in cleads:
                     if event_type == 'bounce':
                         cl.status = 'BOUNCED'
-                        cl.save(update_fields=['status'])
+                        if bounce_details['bounce_type']:
+                            cl.bounce_type = bounce_details['bounce_type']
+                        if bounce_details['bounce_code']:
+                            cl.bounce_code = bounce_details['bounce_code']
+                        if bounce_details['bounce_reason']:
+                            cl.bounce_reason = bounce_details['bounce_reason']
+                        cl.save(update_fields=[
+                            'status',
+                            'bounce_type',
+                            'bounce_code',
+                            'bounce_reason',
+                        ])
+                        logger.info(
+                            'Webhook bounce processed for email=%s type=%s code=%s reason=%s',
+                            lead_email,
+                            cl.bounce_type or 'unknown',
+                            cl.bounce_code or 'unknown',
+                            cl.bounce_reason or 'unknown',
+                        )
                     elif event_type == 'reply':
                         cl.last_replied_at = now
                         # Only hard-stop if there is no reply-yes branch configured.


### PR DESCRIPTION
Closes #203

## Summary
- stores bounce metadata from email webhooks on CampaignLead records
- parses bounce type, provider code, and human-readable reason from common payload shapes
- logs bounce details so operators can troubleshoot soft bounces faster
- adds a regression test for persisted bounce metadata

## Validation
- `git diff --check`
- `python3 manage.py test campaigns.tests.CampaignWorkflowTests.test_email_webhook_persists_bounce_metadata campaigns.tests.CampaignWorkflowTests.test_email_webhook_logs_processing_errors`
