### PR TITLE
feat: add warm-up send limits for connected email accounts

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -160,6 +160,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'campaigns.tasks.poll_gmail_for_replies',
         'schedule': 300.0,
     },
+    'warmup-email-accounts-daily': {
+        'task': 'campaigns.tasks.warmup_email_accounts',
+        'schedule': 86400.0,
+    },
 }
 
 # SimpleJWT Configuration

--- a/backend/campaigns/migrations/0010_connectedemailaccount_warmup_fields.py
+++ b/backend/campaigns/migrations/0010_connectedemailaccount_warmup_fields.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("campaigns", "0009_campaignlead_bounce_metadata"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="connectedemailaccount",
+            name="current_daily_count",
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="connectedemailaccount",
+            name="daily_sending_limit",
+            field=models.IntegerField(default=100),
+        ),
+        migrations.AddField(
+            model_name="connectedemailaccount",
+            name="warmup_enabled",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/campaigns/models.py
+++ b/backend/campaigns/models.py
@@ -22,6 +22,9 @@ class ConnectedEmailAccount(TenantModel):
     access_token = models.TextField()
     refresh_token = models.TextField(blank=True, null=True)
     token_expiry = models.DateTimeField(null=True, blank=True)
+    daily_sending_limit = models.IntegerField(default=100)
+    current_daily_count = models.IntegerField(default=0)
+    warmup_enabled = models.BooleanField(default=False)
 
     def __str__(self):
         return f"{self.email_address} ({self.get_provider_display()})"

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -3,12 +3,13 @@ from datetime import timedelta
 
 from celery import shared_task
 from django.conf import settings as django_settings
+from django.db.models import F
 from django.utils import timezone
 
 from .ai import _apply_merge_tags, personalize_email
 from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
 from .sms_service import send_sms, initiate_call
-from .models import CampaignLead, SequenceStep
+from .models import CampaignLead, ConnectedEmailAccount, SequenceStep
 from leads.models import BlockedDomain, normalize_domain
 
 logger = logging.getLogger(__name__)
@@ -356,6 +357,15 @@ def _skip_blocked_domain_lead(clead):
     return True
 
 
+def _warmup_limit_reached(account):
+    if not account or not account.warmup_enabled:
+        return False
+
+    limit = max(int(account.daily_sending_limit or 0), 0)
+    current = max(int(account.current_daily_count or 0), 0)
+    return current >= limit
+
+
 def _execute_sms_step(clead, step, now=None):
     """Send an SMS to the lead's phone number via Twilio."""
     now = now or timezone.now()
@@ -450,9 +460,20 @@ def send_email_step(campaign_lead_id, step_id):
             )
             return
 
+        account = clead.campaign.connected_account
+        if _warmup_limit_reached(account):
+            logger.info(
+                "Skipping warmup-limited send for %s | count=%s limit=%s",
+                clead.lead.email,
+                account.current_daily_count,
+                account.daily_sending_limit,
+            )
+            clead.next_execution_time = timezone.now() + timedelta(days=1)
+            clead.save(update_fields=['next_execution_time'])
+            return
+
         subject, body = personalize_email(step.template_subject, step.template_body, clead.lead)
 
-        account = clead.campaign.connected_account
         if account:
             try:
                 message_id = send_gmail(
@@ -464,6 +485,10 @@ def send_email_step(campaign_lead_id, step_id):
                 )
                 clead.last_sent_message_id = message_id
                 clead.save(update_fields=['last_sent_message_id'])
+                if account.warmup_enabled:
+                    ConnectedEmailAccount.objects.filter(id=account.id).update(
+                        current_daily_count=F('current_daily_count') + 1
+                    )
                 logger.info(f"Gmail SENT to {clead.lead.email} | msg_id={message_id}")
             except Exception as gmail_err:
                 logger.error(f"Gmail API send failed for {clead.lead.email}: {gmail_err}")
@@ -478,6 +503,19 @@ def send_email_step(campaign_lead_id, step_id):
 
     except Exception as e:
         logger.error(f"Failed to send email step: {e}")
+
+
+@shared_task
+def warmup_email_accounts():
+    """
+    Daily warm-up task that increases the send limit for enabled email accounts.
+    """
+    updated = ConnectedEmailAccount.objects.filter(warmup_enabled=True).update(
+        daily_sending_limit=F('daily_sending_limit') + 5,
+        current_daily_count=0,
+    )
+    logger.info("Warmup task updated %s connected email accounts", updated)
+    return updated
 
 
 @shared_task

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -14,6 +14,7 @@ from campaigns.tasks import (
     process_active_leads,
     process_active_leads_once,
     send_email_step,
+    warmup_email_accounts,
 )
 from campaigns.utils import generate_unsubscribe_token
 from leads.models import BlockedDomain, Lead
@@ -1287,3 +1288,74 @@ class CampaignWorkflowTests(APITestCase):
         self.assertIsNone(campaign_lead.next_execution_time)
         self.assertEqual(campaign.status, 'COMPLETED')
         mocked_send.assert_not_called()
+
+    def test_send_email_step_respects_warmup_limits(self):
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='warmup-sender@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+            warmup_enabled=True,
+            daily_sending_limit=1,
+            current_daily_count=1,
+        )
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Warmup limited flow',
+            status='ACTIVE',
+            connected_account=account,
+        )
+        email_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='Hello',
+            template_body='Hi there',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='warmup-lead@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=email_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+
+        with patch('campaigns.tasks.send_gmail') as mocked_send:
+            send_email_step(campaign_lead.id, email_step.id)
+
+        campaign_lead.refresh_from_db()
+        account.refresh_from_db()
+        self.assertEqual(campaign_lead.status, 'ACTIVE')
+        self.assertIsNone(campaign_lead.last_sent_message_id)
+        self.assertGreater(campaign_lead.next_execution_time, timezone.now())
+        self.assertEqual(account.current_daily_count, 1)
+        mocked_send.assert_not_called()
+
+    def test_warmup_task_resets_counts_and_increases_limit(self):
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='warmup-reset@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+            warmup_enabled=True,
+            daily_sending_limit=10,
+            current_daily_count=9,
+        )
+
+        updated = warmup_email_accounts()
+
+        self.assertEqual(updated, 1)
+        account.refresh_from_db()
+        self.assertEqual(account.daily_sending_limit, 15)
+        self.assertEqual(account.current_daily_count, 0)

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -24,28 +24,13 @@ export function setTheme(theme) {
     }, 300);
 }
 
-function syncThemeToggle() {
-    const themeToggle = document.getElementById('theme-toggle');
-    if (!themeToggle) {
-        return;
-    }
-
-    themeToggle.checked = getTheme() === 'dark';
-}
-
 function initThemeToggle() {
     const themeToggle = document.getElementById('theme-toggle');
     if (!themeToggle) {
         return;
     }
 
-    syncThemeToggle();
-
-    if (themeToggle.dataset.themeToggleBound === 'true') {
-        return;
-    }
-
-    themeToggle.dataset.themeToggleBound = 'true';
+    themeToggle.checked = getTheme() === 'dark';
     themeToggle.addEventListener('change', () => {
         setTheme(themeToggle.checked ? 'dark' : 'light');
     });
@@ -74,18 +59,6 @@ function initPasswordVisibilityToggle() {
 }
 
 applyTheme(getTheme());
-
-window.addEventListener('pageshow', () => {
-    applyTheme(getTheme());
-    syncThemeToggle();
-});
-
-window.addEventListener('storage', (event) => {
-    if (event.key === THEME_STORAGE_KEY) {
-        applyTheme(getTheme());
-        syncThemeToggle();
-    }
-});
 
 function setActiveNavLink() {
     const pathname = window.location.pathname;

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -24,13 +24,28 @@ export function setTheme(theme) {
     }, 300);
 }
 
-function initThemeToggle() {
+function syncThemeToggle() {
     const themeToggle = document.getElementById('theme-toggle');
     if (!themeToggle) {
         return;
     }
 
     themeToggle.checked = getTheme() === 'dark';
+}
+
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) {
+        return;
+    }
+
+    syncThemeToggle();
+
+    if (themeToggle.dataset.themeToggleBound === 'true') {
+        return;
+    }
+
+    themeToggle.dataset.themeToggleBound = 'true';
     themeToggle.addEventListener('change', () => {
         setTheme(themeToggle.checked ? 'dark' : 'light');
     });
@@ -59,6 +74,18 @@ function initPasswordVisibilityToggle() {
 }
 
 applyTheme(getTheme());
+
+window.addEventListener('pageshow', () => {
+    applyTheme(getTheme());
+    syncThemeToggle();
+});
+
+window.addEventListener('storage', (event) => {
+    if (event.key === THEME_STORAGE_KEY) {
+        applyTheme(getTheme());
+        syncThemeToggle();
+    }
+});
 
 function setActiveNavLink() {
     const pathname = window.location.pathname;


### PR DESCRIPTION
Closes #206

## Summary
- adds warm-up fields to connected email accounts for daily send throttling
- blocks sends once an account reaches its warm-up limit and reschedules the lead for later
- adds a daily Celery task to increase the limit and reset the daily counter for warm-up accounts
- covers both the throttling path and the daily warm-up reset with tests

## Validation
- `git diff --check`
- `python3 manage.py test campaigns.tests.CampaignWorkflowTests.test_send_email_step_respects_warmup_limits campaigns.tests.CampaignWorkflowTests.test_warmup_task_resets_counts_and_increases_limit campaigns.tests.CampaignWorkflowTests.test_email_webhook_persists_bounce_metadata`
