### PR TITLE
LO-038: Fix dark mode toggle binding in Workspace Settings

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -24,13 +24,28 @@ export function setTheme(theme) {
     }, 300);
 }
 
-function initThemeToggle() {
+function syncThemeToggle() {
     const themeToggle = document.getElementById('theme-toggle');
     if (!themeToggle) {
         return;
     }
 
     themeToggle.checked = getTheme() === 'dark';
+}
+
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) {
+        return;
+    }
+
+    syncThemeToggle();
+
+    if (themeToggle.dataset.themeToggleBound === 'true') {
+        return;
+    }
+
+    themeToggle.dataset.themeToggleBound = 'true';
     themeToggle.addEventListener('change', () => {
         setTheme(themeToggle.checked ? 'dark' : 'light');
     });
@@ -59,6 +74,18 @@ function initPasswordVisibilityToggle() {
 }
 
 applyTheme(getTheme());
+
+window.addEventListener('pageshow', () => {
+    applyTheme(getTheme());
+    syncThemeToggle();
+});
+
+window.addEventListener('storage', (event) => {
+    if (event.key === THEME_STORAGE_KEY) {
+        applyTheme(getTheme());
+        syncThemeToggle();
+    }
+});
 
 function setActiveNavLink() {
     const pathname = window.location.pathname;


### PR DESCRIPTION
## Summary\n- Sync the Workspace Settings theme toggle from the stored theme value before and after binding.\n- Guard the toggle listener so it is attached once, even when the page is revisited from bfcache.\n- Refresh the toggle state on pageshow and storage events so the preference stays in sync across navigation.\n\n## Testing\n- Verified the settings page responds locally via the static server.\n- Checked the patch for syntax consistency and duplicate listener removal.\n\nCloses #217