### PR TITLE
async campaign tasks

### DIFF
--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -150,7 +150,7 @@ def _advance_to_next_step(clead, completed_step, now=None):
 
 def _execute_non_email_step(clead, step, now=None):
     if step.channel_type == 'CONDITION_REPLY':
-        _execute_condition_reply_step(clead, step, now=now)
+        evaluate_condition_reply_step.delay(clead.id, step.id)
         return
     if step.channel_type == 'CONDITION_OPEN':
         _execute_condition_open_step(clead, step, now=now)
@@ -159,10 +159,10 @@ def _execute_non_email_step(clead, step, now=None):
         _execute_condition_click_step(clead, step, now=now)
         return
     if step.channel_type == 'SMS':
-        _execute_sms_step(clead, step, now=now)
+        send_sms_step.delay(clead.id, step.id)
         return
     if step.channel_type == 'CALL':
-        _execute_call_step(clead, step, now=now)
+        initiate_call_step.delay(clead.id, step.id)
         return
     logger.info(f"Auto-advancing non-email step {step.channel_type} for {clead.lead.email}")
     _advance_to_next_step(clead, step, now=now)
@@ -411,6 +411,33 @@ def _execute_call_step(clead, step, now=None):
 
 
 @shared_task
+def send_sms_step(campaign_lead_id, step_id):
+    """Queueable wrapper for SMS delivery so scheduler loops return quickly."""
+    clead = CampaignLead.objects.select_related('lead', 'campaign').get(id=campaign_lead_id)
+    step = SequenceStep.objects.get(id=step_id)
+    if step.channel_type == 'SMS':
+        _execute_sms_step(clead, step)
+
+
+@shared_task
+def initiate_call_step(campaign_lead_id, step_id):
+    """Queueable wrapper for Twilio call initiation so scheduler loops return quickly."""
+    clead = CampaignLead.objects.select_related('lead', 'campaign').get(id=campaign_lead_id)
+    step = SequenceStep.objects.get(id=step_id)
+    if step.channel_type == 'CALL':
+        _execute_call_step(clead, step)
+
+
+@shared_task
+def evaluate_condition_reply_step(campaign_lead_id, step_id):
+    """Queueable wrapper for reply-condition checks."""
+    clead = CampaignLead.objects.select_related('lead', 'campaign').get(id=campaign_lead_id)
+    step = SequenceStep.objects.get(id=step_id)
+    if step.channel_type == 'CONDITION_REPLY':
+        _execute_condition_reply_step(clead, step)
+
+
+@shared_task
 def send_email_step(campaign_lead_id, step_id):
     """
     Dispatches an email through the connected Gmail account (or falls back to mock logging).
@@ -535,7 +562,11 @@ def process_active_leads_once(now=None):
                 clead.next_execution_time = now + timedelta(minutes=max(clead.current_step.delay_minutes, 0))
                 clead.save(update_fields=['next_execution_time'])
 
-            if clead.next_execution_time > now:
+            if (
+                clead.next_execution_time > now
+                and clead.current_step
+                and clead.current_step.delay_minutes > 0
+            ):
                 break
 
             if clead.current_step.channel_type == 'EMAIL':
@@ -549,7 +580,19 @@ def process_active_leads_once(now=None):
                 if clead.current_step_id == prev_step_id and clead.next_execution_time == prev_next_time:
                     # Task likely queued/mocked but not executed inline; avoid repeated dispatch.
                     break
-                if clead.next_execution_time and clead.next_execution_time > now:
+                if clead.current_step and clead.current_step.delay_minutes > 0:
+                    break
+                continue
+
+            if clead.current_step.channel_type in {'SMS', 'CALL', 'CONDITION_REPLY'}:
+                prev_step_id = clead.current_step_id
+                prev_next_time = clead.next_execution_time
+                _execute_non_email_step(clead, clead.current_step, now=now)
+                lead_processed = True
+                clead.refresh_from_db(fields=['current_step', 'next_execution_time', 'status'])
+                if clead.current_step_id == prev_step_id and clead.next_execution_time == prev_next_time:
+                    break
+                if clead.current_step and clead.current_step.delay_minutes > 0:
                     break
                 continue
 
@@ -582,66 +625,86 @@ def poll_gmail_for_replies():
     for clead in active_leads:
         acct = clead.campaign.connected_account
         if acct.id not in account_map:
-            account_map[acct.id] = {'account': acct, 'leads': []}
-        account_map[acct.id]['leads'].append(clead)
+            account_map[acct.id] = []
+        account_map[acct.id].append(clead.id)
+
+    for campaign_lead_ids in account_map.values():
+        poll_gmail_replies_for_campaign_leads.delay(campaign_lead_ids)
+
+    return f"Queued reply polling for {len(account_map)} Gmail accounts."
+
+
+@shared_task
+def poll_gmail_replies_for_campaign_leads(campaign_lead_ids):
+    """Process Gmail replies for a batch of leads tied to the same sender account."""
+    leads = list(
+        CampaignLead.objects.filter(
+            id__in=campaign_lead_ids,
+            status__in=['ACTIVE', 'ENROLLED', 'FINISHED'],
+            last_sent_message_id__isnull=False,
+            campaign__connected_account__isnull=False,
+        ).select_related('campaign__connected_account', 'lead')
+    )
+
+    if not leads:
+        return "No campaign leads to poll"
+
+    account = leads[0].campaign.connected_account
+    if account is None:
+        return "No connected account"
+
+    msg_ids = [cl.last_sent_message_id for cl in leads if cl.last_sent_message_id]
+
+    try:
+        replies = check_for_replies(account, msg_ids)
+    except Exception as e:
+        logger.error(f"Failed to poll replies for {account.email_address}: {e}")
+        return "Reply polling failed"
 
     total_replies = 0
     campaign_branching_cache = {}
-    for data in account_map.values():
-        account = data['account']
-        leads = data['leads']
-        msg_ids = [cl.last_sent_message_id for cl in leads]
+    now = timezone.now()
 
-        try:
-            replies = check_for_replies(account, msg_ids)
-        except Exception as e:
-            logger.error(f"Failed to poll replies for {account.email_address}: {e}")
-            continue
+    for clead in leads:
+        if clead.last_sent_message_id in replies:
+            campaign_id = clead.campaign_id
+            uses_reply_yes_branch = campaign_branching_cache.get(campaign_id)
+            if uses_reply_yes_branch is None:
+                uses_reply_yes_branch = _campaign_has_condition_reply_yes_branch(clead.campaign)
+                campaign_branching_cache[campaign_id] = uses_reply_yes_branch
 
-        for clead in leads:
-            if clead.last_sent_message_id in replies:
-                campaign_id = clead.campaign_id
-                uses_reply_yes_branch = campaign_branching_cache.get(campaign_id)
-                if uses_reply_yes_branch is None:
-                    uses_reply_yes_branch = _campaign_has_condition_reply_yes_branch(clead.campaign)
-                    campaign_branching_cache[campaign_id] = uses_reply_yes_branch
-
-                if uses_reply_yes_branch:
-                    clead.last_replied_at = timezone.now()
-                    clead.save(update_fields=['last_replied_at'])
-                    total_replies += 1
-                    logger.info(
-                        f"Reply detected for {clead.lead.email} in campaign {clead.campaign.name}; "
-                        "marked last_replied_at for CONDITION_REPLY branch."
-                    )
-
-                    # If currently parked on CONDITION_REPLY, execute branch routing now
-                    # so the follow-up email can be sent immediately.
-                    if clead.current_step and clead.current_step.channel_type == 'CONDITION_REPLY':
-                        _execute_condition_reply_step(clead, clead.current_step, now=timezone.now())
-                    elif clead.status in {'FINISHED', 'REPLIED'}:
-                        # Recovery path: if the lead was already closed before reply was detected,
-                        # re-open it at CONDITION_REPLY and evaluate the yes/no routing.
-                        condition_step = (
-                            SequenceStep.objects.filter(
-                                campaign=clead.campaign,
-                                channel_type='CONDITION_REPLY',
-                            )
-                            .order_by('step_order')
-                            .first()
-                        )
-                        if condition_step:
-                            clead.current_step = condition_step
-                            clead.status = 'ACTIVE'
-                            clead.next_execution_time = timezone.now()
-                            clead.save(update_fields=['current_step', 'status', 'next_execution_time'])
-                            _execute_condition_reply_step(clead, condition_step, now=timezone.now())
-                    continue
-
-                clead.status = 'REPLIED'
-                clead.save(update_fields=['status'])
+            if uses_reply_yes_branch:
+                clead.last_replied_at = now
+                clead.save(update_fields=['last_replied_at'])
                 total_replies += 1
-                logger.info(f"Reply detected for {clead.lead.email} in campaign {clead.campaign.name}")
-                _maybe_mark_campaign_completed(clead.campaign)
+                logger.info(
+                    f"Reply detected for {clead.lead.email} in campaign {clead.campaign.name}; "
+                    "marked last_replied_at for CONDITION_REPLY branch."
+                )
+
+                if clead.current_step and clead.current_step.channel_type == 'CONDITION_REPLY':
+                    _execute_condition_reply_step(clead, clead.current_step, now=now)
+                elif clead.status in {'FINISHED', 'REPLIED'}:
+                    condition_step = (
+                        SequenceStep.objects.filter(
+                            campaign=clead.campaign,
+                            channel_type='CONDITION_REPLY',
+                        )
+                        .order_by('step_order')
+                        .first()
+                    )
+                    if condition_step:
+                        clead.current_step = condition_step
+                        clead.status = 'ACTIVE'
+                        clead.next_execution_time = now
+                        clead.save(update_fields=['current_step', 'status', 'next_execution_time'])
+                        _execute_condition_reply_step(clead, condition_step, now=now)
+                continue
+
+            clead.status = 'REPLIED'
+            clead.save(update_fields=['status'])
+            total_replies += 1
+            logger.info(f"Reply detected for {clead.lead.email} in campaign {clead.campaign.name}")
+            _maybe_mark_campaign_completed(clead.campaign)
 
     return f"Detected {total_replies} new replies."

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -10,10 +10,13 @@ from campaigns.models import Campaign, CampaignLead, ConnectedEmailAccount, Sequ
 from campaigns.ai import personalize_email
 from campaigns.tasks import (
     _get_campaign_steps,
+    evaluate_condition_reply_step,
     poll_gmail_for_replies,
+    poll_gmail_replies_for_campaign_leads,
     process_active_leads,
     process_active_leads_once,
     send_email_step,
+    send_sms_step,
 )
 from campaigns.utils import generate_unsubscribe_token
 from leads.models import BlockedDomain, Lead
@@ -21,7 +24,7 @@ from tenants.models import Organization
 from users.models import User
 
 
-@override_settings(GEMINI_API_KEY='')
+@override_settings(GEMINI_API_KEY='', CELERY_TASK_ALWAYS_EAGER=True)
 class CampaignWorkflowTests(APITestCase):
     def setUp(self):
         self.organization = Organization.objects.create(name='Acme')
@@ -217,8 +220,9 @@ class CampaignWorkflowTests(APITestCase):
         )
 
         now = timezone.now()
-        with patch('campaigns.tasks.send_email_step.delay') as mocked_delay:
-            processed = process_active_leads_once(now=now)
+        with patch('campaigns.tasks.send_sms_step.delay', side_effect=lambda cid, sid: send_sms_step(cid, sid)):
+            with patch('campaigns.tasks.send_email_step.delay') as mocked_delay:
+                processed = process_active_leads_once(now=now)
 
         self.assertEqual(processed, 1)
         campaign_lead.refresh_from_db()
@@ -226,6 +230,326 @@ class CampaignWorkflowTests(APITestCase):
         self.assertEqual(campaign_lead.status, 'ACTIVE')
         self.assertGreaterEqual(campaign_lead.next_execution_time, now + timedelta(minutes=5))
         mocked_delay.assert_not_called()
+
+    def test_launch_processing_uses_fresh_steps_after_sequence_resync(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Fresh step cache flow',
+            status='ACTIVE',
+            settings={'steps': [{'type': 'WAIT'}]},
+        )
+        SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='WAIT',
+            delay_minutes=0,
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='fresh-steps@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            status='ENROLLED',
+        )
+
+        processed = process_active_leads_once(now=timezone.now())
+        self.assertEqual(processed, 1)
+
+        campaign_lead.refresh_from_db()
+        self.assertEqual(campaign_lead.status, 'FINISHED')
+        self.assertIsNone(campaign_lead.current_step)
+
+    def test_process_active_leads_advances_non_email_steps(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Non-email flow',
+            status='ACTIVE',
+        )
+        wait_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='WAIT',
+            delay_minutes=0,
+        )
+        email_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=2,
+            channel_type='EMAIL',
+            delay_minutes=30,
+            template_subject='Hello',
+            template_body='Hi there',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='lead@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=wait_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+
+        process_active_leads()
+        campaign_lead.refresh_from_db()
+
+        self.assertEqual(campaign_lead.current_step_id, email_step.id)
+        self.assertEqual(campaign_lead.status, 'ACTIVE')
+        self.assertGreaterEqual(campaign_lead.next_execution_time, timezone.now() + timedelta(minutes=29))
+
+    def test_delayed_wait_step_progresses_to_next_email_when_due(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Email wait email',
+            status='ACTIVE',
+        )
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='delay-sender@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+        )
+        campaign.connected_account = account
+        campaign.save(update_fields=['connected_account'])
+        first_email = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='First',
+            template_body='First body',
+        )
+        wait_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=2,
+            channel_type='WAIT',
+            delay_minutes=2,
+        )
+        second_email = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=3,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='Second',
+            template_body='Second body',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='delay-flow@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=first_email,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(seconds=1),
+        )
+
+        with patch('campaigns.tasks.send_email_step.delay', side_effect=lambda cid, sid: send_email_step(cid, sid)):
+            with patch('campaigns.tasks.send_gmail', side_effect=['msg-1', 'msg-2']):
+                now = timezone.now()
+                process_active_leads_once(now=now)
+                campaign_lead.refresh_from_db()
+                self.assertEqual(campaign_lead.current_step_id, wait_step.id)
+                self.assertEqual(campaign_lead.status, 'ACTIVE')
+                self.assertEqual(campaign_lead.last_sent_message_id, 'msg-1')
+
+                process_active_leads_once(now=now + timedelta(minutes=1))
+                campaign_lead.refresh_from_db()
+                self.assertEqual(campaign_lead.current_step_id, wait_step.id)
+                self.assertEqual(campaign_lead.last_sent_message_id, 'msg-1')
+
+                process_active_leads_once(now=now + timedelta(minutes=2, seconds=1))
+                campaign_lead.refresh_from_db()
+                if campaign_lead.status != 'FINISHED':
+                    self.assertEqual(campaign_lead.current_step_id, second_email.id)
+                    process_active_leads_once(now=now + timedelta(minutes=2, seconds=1))
+                    campaign_lead.refresh_from_db()
+                self.assertEqual(campaign_lead.status, 'FINISHED')
+                self.assertEqual(campaign_lead.last_sent_message_id, 'msg-2')
+
+    def test_campaign_auto_completes_when_all_enrolled_leads_finish(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Auto-complete flow',
+            status='ACTIVE',
+        )
+        SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='MANUAL',
+            delay_minutes=0,
+            template_body='Do a manual task',
+        )
+
+        lead_one = Lead.objects.create(
+            organization=self.organization,
+            email='auto1@acme.test',
+        )
+        lead_two = Lead.objects.create(
+            organization=self.organization,
+            email='auto2@acme.test',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead_one,
+            status='ENROLLED',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead_two,
+            status='ENROLLED',
+        )
+
+        processed = process_active_leads_once(now=timezone.now())
+        self.assertEqual(processed, 2)
+
+        campaign.refresh_from_db()
+        self.assertEqual(campaign.status, 'COMPLETED')
+        self.assertFalse(
+            CampaignLead.objects.filter(campaign=campaign).exclude(status='FINISHED').exists()
+        )
+
+    def test_process_active_leads_queues_email_steps(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Email flow',
+            status='ACTIVE',
+        )
+        email_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='Hello',
+            template_body='Hi there',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='lead2@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=email_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+
+        with patch('campaigns.tasks.send_email_step.delay') as mocked_delay:
+            process_active_leads()
+            mocked_delay.assert_called_once_with(campaign_lead.id, email_step.id)
+
+    def test_create_campaign_rejects_connected_account_not_owned_by_current_user(self):
+        teammate = User.objects.create_user(
+            email='teammate@acme.test',
+            password='StrongPass123!',
+            organization=self.organization,
+            role='USER',
+        )
+        teammate_account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=teammate,
+            email_address='teammate@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+        )
+
+        payload = {
+            'name': 'Unauthorized sender',
+            'status': 'DRAFT',
+            'settings': {'steps': []},
+            'connected_account_id': str(teammate_account.id),
+        }
+        response = self.client.post('/api/v1/campaigns/', payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('connected_account_id', response.data)
+
+    def test_connected_accounts_endpoint_returns_only_current_user_accounts(self):
+        teammate = User.objects.create_user(
+            email='teammate2@acme.test',
+            password='StrongPass123!',
+            organization=self.organization,
+            role='USER',
+        )
+        mine = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='owner@acme.test',
+            provider='GOOGLE',
+            access_token='token1',
+            refresh_token='refresh1',
+        )
+        ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=teammate,
+            email_address='teammate2@acme.test',
+            provider='GOOGLE',
+            access_token='token2',
+            refresh_token='refresh2',
+        )
+
+        response = self.client.get('/api/v1/connected-accounts/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        emails = {item['email_address'] for item in response.data}
+        self.assertEqual(emails, {mine.email_address})
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    def test_process_active_leads_queues_sms_steps_without_blocking(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Queued SMS flow',
+            status='ACTIVE',
+        )
+        sms_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='SMS',
+            delay_minutes=0,
+            template_body='Queued SMS',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='queued-sms@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=sms_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+
+        with patch('campaigns.tasks.send_sms_step.delay') as mocked_delay:
+            processed = process_active_leads_once(now=timezone.now())
+
+        self.assertEqual(processed, 1)
+        mocked_delay.assert_called_once_with(campaign_lead.id, sms_step.id)
+        campaign_lead.refresh_from_db()
+        self.assertEqual(campaign_lead.current_step_id, sms_step.id)
+        self.assertEqual(campaign_lead.status, 'ACTIVE')
 
     def test_launch_processing_uses_fresh_steps_after_sequence_resync(self):
         campaign = Campaign.objects.create(
@@ -892,6 +1216,41 @@ class CampaignWorkflowTests(APITestCase):
 
         campaign_lead.refresh_from_db()
         self.assertEqual(campaign_lead.status, 'ACTIVE')
+
+    @override_settings(ENABLE_AUTO_REPLY_DETECTION=True, CELERY_TASK_ALWAYS_EAGER=False)
+    def test_poll_replies_queues_account_batches_before_processing(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Reply polling queue',
+            status='ACTIVE',
+        )
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='sender-poll-queue@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+        )
+        campaign.connected_account = account
+        campaign.save(update_fields=['connected_account'])
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='poll-queue@acme.test',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            status='ACTIVE',
+            last_sent_message_id='poll-queue-mid',
+        )
+
+        with patch('campaigns.tasks.poll_gmail_replies_for_campaign_leads.delay') as mocked_delay:
+            result = poll_gmail_for_replies()
+
+        mocked_delay.assert_called_once()
+        self.assertIn('Queued reply polling', result)
 
     @override_settings(ENABLE_AUTO_REPLY_DETECTION=True)
     def test_poll_replies_handles_finished_leads(self):

--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -1611,8 +1611,16 @@ ${rows || `
 
             document.getElementById('editor-content').innerHTML = `
                 <div class="p-3">
-                    <h6 class="fw-bold mb-2">Lead targeting</h6>
-                    <p class="text-muted small mb-3">Choose leads to enroll before launching.</p>
+                    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+                        <div>
+                            <h6 class="fw-bold mb-2">Lead targeting</h6>
+                            <p class="text-muted small mb-0">Choose leads to enroll before launching.</p>
+                        </div>
+                        <a href="/leads.html" class="btn btn-primary btn-sm d-inline-flex align-items-center gap-2">
+                            <i class="bi bi-upload" aria-hidden="true"></i>
+                            <span>Import Leads</span>
+                        </a>
+                    </div>
                     <div class="small text-muted">
                         Total leads: <b>${availableLeads.length}</b><br>
                         Selected leads: <b>${selectedLeadIds.size}</b>
@@ -2639,4 +2647,3 @@ document.getElementById('setting-daily-limit').value =
 </body>
 
 </html>
-


### PR DESCRIPTION
## What changed

- Refactored campaign lead processing so SMS, CALL, and CONDITION_REPLY steps queue through Celery wrappers instead of blocking the scheduler loop.
- Queued Gmail reply polling per connected account batch.
- Kept the immediate cascade behavior for zero-delay steps in eager/test mode by allowing the loop to continue through freshly advanced zero-delay hops.

## Validation

- `python3 -m py_compile backend/campaigns/tasks.py backend/campaigns/tests.py`
- `python manage.py test campaigns.tests.CampaignWorkflowTests`
