### PR TITLE
fix: restore login card container structure

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -100,7 +100,6 @@
                                         placeholder="name@example.com" required style="border-left: none !important;">
                                 </div>
                             </div>
-                            </div>
 
 <div class="mb-4">
     <label for="floatingPassword" class="form-label text-muted small fw-semibold">


### PR DESCRIPTION
## Summary

This is a follow-up fix for PR #159.

A stray closing `</div>` in `frontend/login.html` prematurely closed the card containers, causing the password field, visibility toggle, and sign-in button to render outside the intended glass card structure.

## Changes
* Removed the extra closing `</div>` from the login form markup.
* Restored the correct nesting of the email and password form sections.
* Ensured the password field, visibility toggle, and sign-in button remain inside the login card.
* Preserved the password visibility toggle behavior introduced in #159.

## Testing

Manually verified:
* Login card renders with the correct container structure.
* Email field remains inside the card.
* Password field remains inside the card.
* Sign-in button remains inside the card.
* Password show/hide toggle continues to work.
* No browser console errors were observed.

## Screenshot

### Corrected login page
<img width="1911" height="931" alt="image" src="https://github.com/user-attachments/assets/efbcb4f1-4474-4d3e-9570-119c5daae8e0" />


Follow-up to #159.
Closes #126.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected malformed markup in the login form's email input field to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->