### PR TITLE
docs: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Report a bug to help us improve LeadOrbit
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+
+* type: markdown
+  attributes:
+  value: |
+  Thanks for taking the time to fill out this bug report!
+
+* type: textarea
+  id: description
+  attributes:
+  label: Bug Description
+  description: A clear and concise description of the bug.
+  placeholder: Describe the bug...
+  validations:
+  required: true
+
+* type: textarea
+  id: steps
+  attributes:
+  label: Steps to Reproduce
+  description: Steps to reproduce the behavior.
+  placeholder: |
+  1. Go to '...'
+  2. Click on '...'
+  3. Perform an action
+  4. See the error
+  validations:
+  required: true
+
+* type: textarea
+  id: expected
+  attributes:
+  label: Expected Behavior
+  description: What did you expect to happen?
+  placeholder: Describe the expected behavior...
+  validations:
+  required: true
+
+* type: textarea
+  id: actual
+  attributes:
+  label: Actual Behavior
+  description: What actually happened?
+  placeholder: Describe the actual behavior...
+  validations:
+  required: true
+
+* type: textarea
+  id: screenshots
+  attributes:
+  label: Screenshots
+  description: If applicable, add screenshots to help explain the issue.
+  placeholder: Drag and drop screenshots here...
+  validations:
+  required: false
+
+* type: dropdown
+  id: os
+  attributes:
+  label: Operating System
+  options:
+  - Windows
+  - macOS
+  - Linux
+  - Other
+  validations:
+  required: true
+
+* type: dropdown
+  id: browser
+  attributes:
+  label: Browser
+  options:
+  - Chrome
+  - Firefox
+  - Safari
+  - Edge
+  - Other
+  validations:
+  required: true
+
+* type: textarea
+  id: additional
+  attributes:
+  label: Additional Context
+  description: Add any other context, logs, or details about the issue.
+  placeholder: Additional information...
+  validations:
+  required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+
+contact_links:
+
+* name: 📖 Read the Documentation
+  url: https://github.com/Kuldeeep18/LeadOrbit/blob/main/README.md
+  about: Check the README before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest a new feature or improvement for LeadOrbit
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+
+* type: markdown
+  attributes:
+  value: |
+  Thanks for suggesting an improvement! Please provide the details below.
+
+* type: textarea
+  id: problem
+  attributes:
+  label: Problem Statement
+  description: Describe the problem this feature would solve.
+  placeholder: Currently there is no way to...
+  validations:
+  required: true
+
+* type: textarea
+  id: solution
+  attributes:
+  label: Proposed Solution
+  description: Describe the solution you would like to see.
+  placeholder: I would like LeadOrbit to...
+  validations:
+  required: true
+
+* type: textarea
+  id: alternatives
+  attributes:
+  label: Alternatives Considered
+  description: Describe any alternative solutions or workarounds you have considered.
+  placeholder: I also considered...
+  validations:
+  required: false
+
+* type: textarea
+  id: acceptance
+  attributes:
+  label: Acceptance Criteria
+  description: Define how this feature can be considered complete.
+  placeholder: |
+  - User can...
+  - System should...
+  - Feature works when...
+  validations:
+  required: true
+
+* type: textarea
+  id: context
+  attributes:
+  label: Additional Context
+  description: Add any other context, screenshots, or references here.
+  placeholder: Additional information...
+  validations:
+  required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+# Pull Request
+
+## 🔗 Related Issue
+
+Closes #<!-- Issue number -->
+
+---
+
+## 📝 Summary of Changes
+
+<!-- Briefly describe the changes made in this PR -->
+
+---
+
+## 🏷️ Type of Change
+
+* [ ] 🐛 Bug fix
+* [ ] ✨ New feature
+* [ ] ♻️ Refactor
+* [ ] 📝 Documentation update
+* [ ] 🎨 UI / Style change
+* [ ] 🔧 Chore
+
+---
+
+## 🧪 Testing
+
+<!-- Describe how the changes were tested -->
+
+**Steps to test:**
+1.
+2.
+3.
+
+---
+
+## 📸 Screenshots (if applicable)
+
+<!-- Add screenshots for UI-related changes -->
+
+---
+
+## ✅ Checklist
+
+* [ ] No merge conflicts
+* [ ] Changes follow the project guidelines
+* [ ] Documentation updated (if applicable)
+* [ ] Related issue linked
+* [ ] Changes tested locally (if applicable)


### PR DESCRIPTION
## Related Issue

Closes #296

---

## Summary of Changes

Added GitHub Issue Templates and a Pull Request Template to improve contribution consistency and issue reporting.

### Changes made:

* Added `bug_report.yml` for structured bug reports
* Added `feature_request.yml` for feature requests
* Added `config.yml` to enable the template chooser and disable blank issues
* Added `PULL_REQUEST_TEMPLATE.md` for standardized pull requests

**Note:** The issue mentions removing `temp_issue.md` and `temp_issue2.md`, but these files were not present in the repository, so no cleanup was required.

---

## Type of Change

* [ ]  Bug fix
* [ ]  New feature
* [ ]  Refactor
* [x]  Documentation update
* [ ]  UI / Style change
* [ ]  Chore

---

##  Testing

**Steps to test:**

1. Navigate to the "New Issue" page and verify that Bug Report and Feature Request templates are available.
2. Confirm that blank issues are disabled.
3. Open a new Pull Request and verify that the PR template is automatically loaded.

---

##  Screenshots (if applicable)

N/A

---

##  Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [x] Documentation updated (if applicable)
* [x] Related issue linked
* [x] Changes tested locally (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added standardized bug report template for issue submissions.
  * Added feature request template for issue submissions.
  * Added pull request template to streamline contributions.
  * Configured issue template settings with guidance links and blank issue prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->