### PR TITLE
fix: validate CSV upload size

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -129,7 +129,9 @@ USE_I18N = True
 USE_TZ = True
 STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
+MAX_CSV_UPLOAD_SIZE = int(
+    os.getenv("MAX_CSV_UPLOAD_SIZE", 10 * 1024 * 1024)
+)
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -1,7 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 from rest_framework.test import APITestCase
-
+from django.test import override_settings
 from leads.models import BlockedDomain, Lead, Tag, LeadTag, LeadImportJob
 from leads.tasks import import_leads_from_csv
 from tenants.models import Organization
@@ -89,6 +89,38 @@ class LeadImportTests(APITestCase):
         self.assertEqual(job.error_log[0]['error'], 'Invalid email format')
         self.assertEqual(job.error_log[1]['error'], 'Missing email address')
 
+class CsvUploadSizeValidationTests(APITestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name="Upload Limit Org")
+        self.user = _make_user(
+            self.organization,
+            email="upload-limit@example.com",
+        )
+
+    @override_settings(MAX_CSV_UPLOAD_SIZE=10)
+    def test_import_csv_rejects_oversized_file(self):
+        self.client.force_authenticate(self.user)
+
+        uploaded_file = SimpleUploadedFile(
+            "too-large.csv",
+            b"email\n" + b"x" * 11,
+            content_type="text/csv",
+        )
+
+        response = self.client.post(
+            "/api/v1/leads/import_csv/",
+            {"file": uploaded_file},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("maximum allowed upload size", response.data["error"])
+        self.assertEqual(
+            LeadImportJob.objects.filter(
+                organization=self.organization
+            ).count(),
+            0,
+        )
 
 class LeadIsolationAPITests(APITestCase):
     def setUp(self):

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import Q
 from rest_framework import viewsets, parsers, status
 from rest_framework.pagination import PageNumberPagination
@@ -96,7 +97,11 @@ class LeadViewSet(viewsets.ModelViewSet):
         file_obj = request.FILES.get('file')
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
-
+        if file_obj.size > settings.MAX_CSV_UPLOAD_SIZE:
+            return Response(
+                {"error": "CSV file exceeds the maximum allowed upload size."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         job = LeadImportJob.objects.create(
             organization=request.user.organization,
             filename=file_obj.name or 'lead-import.csv',


### PR DESCRIPTION
## 🔗 Related Issue

Closes #327

---

## 📝 Summary of Changes

* Added a configurable `MAX_CSV_UPLOAD_SIZE` setting with a default limit of 10 MB.
* Added validation for CSV upload size before creating an import job or reading file contents.
* Added a regression test to confirm oversized CSV uploads return HTTP 400 and do not create an import job.

---

## 🏷️ Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

Tested locally with:

```bash
cd backend
python manage.py test leads
```

Result: **33 tests passed**

**Steps to test:**

1. Set `MAX_CSV_UPLOAD_SIZE` to a small value using `@override_settings` in the test.
2. Upload a CSV file larger than the configured limit.
3. Confirm the API returns HTTP 400 and no `LeadImportJob` is created.

---

## 📸 Screenshots (if applicable)

Not applicable — backend validation and test coverage only.

---

## ✅ Checklist

* [ ] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (not applicable)
* [x] Related issue linked
* [x] Changes tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV imports now enforce a maximum file size limit (10MB by default). Files exceeding this limit are rejected with a clear error message.

* **Tests**
  * Added test coverage for CSV upload size validation to ensure oversized files are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->