### PR TITLE
fix: cap csv import upload size

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -193,6 +193,9 @@ LAUNCH_IMMEDIATE_PASSES = int(os.getenv('LAUNCH_IMMEDIATE_PASSES', '1' if DEBUG 
 # Email backend (console for dev)
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+# CSV import safety cap to prevent large uploads from being read into memory.
+MAX_CSV_UPLOAD_SIZE = int(os.getenv('MAX_CSV_UPLOAD_SIZE', str(10 * 1024 * 1024)))
+
 # ─── Google OAuth2 / Gmail API ─────────────────────
 BACKEND_BASE_URL = os.getenv(
     'BACKEND_BASE_URL',

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -1,4 +1,5 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -250,6 +251,25 @@ class LeadIsolationAPITests(APITestCase):
         self.assertIn('results', response.data)
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['filename'], 'orga.csv')
+
+    @override_settings(MAX_CSV_UPLOAD_SIZE=10)
+    def test_import_csv_rejects_oversized_files(self):
+        self.client.force_authenticate(self.manager_a)
+        large_file = SimpleUploadedFile(
+            'oversized.csv',
+            b'email\n' + b'a' * 11,
+            content_type='text/csv',
+        )
+
+        response = self.client.post(
+            '/api/v1/leads/import_csv/',
+            {'file': large_file},
+            format='multipart',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('maximum upload size', response.data['error'])
+        self.assertFalse(LeadImportJob.objects.filter(filename='oversized.csv').exists())
 
 
 # ── New tests for Issue #244 ───────────────────────────────────────────────────

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import Q
 from rest_framework import viewsets, parsers, status
 from rest_framework.pagination import PageNumberPagination
@@ -96,6 +97,13 @@ class LeadViewSet(viewsets.ModelViewSet):
         file_obj = request.FILES.get('file')
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
+
+        max_csv_upload_size = getattr(settings, 'MAX_CSV_UPLOAD_SIZE', 10 * 1024 * 1024)
+        if getattr(file_obj, 'size', 0) > max_csv_upload_size:
+            return Response(
+                {"error": f"CSV file exceeds the maximum upload size of {max_csv_upload_size} bytes."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         job = LeadImportJob.objects.create(
             organization=request.user.organization,


### PR DESCRIPTION
## What changed
- added a configurable `MAX_CSV_UPLOAD_SIZE` setting with a 10MB default
- rejected oversized CSV uploads before reading file contents into memory
- added a regression test for oversized file rejection

## Why
- the CSV import endpoint could read arbitrarily large uploads into memory and risk crashing the server

## Validation
- `git diff --check`
- `python3 backend/manage.py test leads.tests.LeadIsolationAPITests.test_import_csv_rejects_oversized_files` could not run in this checkout because the local environment is missing `rest_framework`

Closes #327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV file uploads now have a configurable maximum size limit (default 10MB). Uploads exceeding this limit are rejected with an error response.

* **Tests**
  * Added test coverage to verify oversized CSV uploads are properly rejected by the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->