### PR TITLE
fix: validate campaign leads pagination params

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1516,3 +1516,31 @@ class GoogleOAuthStateTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertIn('google_auth=error', response['Location'])
         self.assertIn('reason=no_user', response['Location'])
+
+    def test_campaign_leads_pagination_rejects_invalid_limit_and_clamps_values(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Pagination guardrail flow',
+            status='DRAFT',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='lead@example.com',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+        )
+
+        invalid_limit = self.client.get(f'/api/v1/campaigns/{campaign.id}/leads/', {'limit': 'abc'})
+        self.assertEqual(invalid_limit.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('Invalid numeric value', invalid_limit.data['error'])
+
+        clamped = self.client.get(
+            f'/api/v1/campaigns/{campaign.id}/leads/',
+            {'limit': '999999', 'offset': '-5'},
+        )
+        self.assertEqual(clamped.status_code, status.HTTP_200_OK)
+        self.assertEqual(clamped.data['limit'], 200)
+        self.assertEqual(clamped.data['offset'], 0)

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -19,6 +19,25 @@ from .serializers import CampaignSerializer, SequenceStepSerializer, EmailTempla
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_bounded_int(raw_value, *, default, minimum, maximum):
+    if raw_value is None:
+        return default, None
+
+    raw_value = str(raw_value).strip()
+    if not raw_value:
+        return default, None
+
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return None, Response(
+            {"error": f"Invalid numeric value: {raw_value}"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return max(minimum, min(value, maximum)), None
+
 class CampaignViewSet(viewsets.ModelViewSet):
     serializer_class = CampaignSerializer
     queryset = Campaign.objects.all()
@@ -269,8 +288,22 @@ class CampaignViewSet(viewsets.ModelViewSet):
         """Get paginated list of enrolled leads with metrics."""
         campaign = self.get_object()
         status_filter = request.query_params.get('status')
-        limit = int(request.query_params.get('limit', 50))
-        offset = int(request.query_params.get('offset', 0))
+        limit, error_response = _parse_bounded_int(
+            request.query_params.get('limit'),
+            default=50,
+            minimum=1,
+            maximum=200,
+        )
+        if error_response:
+            return error_response
+        offset, error_response = _parse_bounded_int(
+            request.query_params.get('offset'),
+            default=0,
+            minimum=0,
+            maximum=10_000,
+        )
+        if error_response:
+            return error_response
 
         leads_qs = campaign.enrolled_leads.select_related('lead').order_by('-updated_at')
 


### PR DESCRIPTION
## What changed
- added bounded integer parsing for campaign leads pagination query params
- returns 400 for non-numeric values instead of crashing the endpoint
- clamps limit and offset to safe ranges
- added a regression test for invalid and oversized values

## Why
- the endpoint could throw a 500 or return unexpected slices when `limit` / `offset` were malformed

## Validation
- `git diff --check`
- `python3 backend/manage.py test campaigns.tests.CampaignWorkflowTests.test_campaign_leads_pagination_rejects_invalid_limit_and_clamps_values` could not run in this checkout because the local environment is missing `rest_framework`

Closes #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Campaign leads pagination endpoints now properly validate input parameters, rejecting invalid numeric values with error responses and clamping out-of-range values to acceptable limits.

* **Tests**
  * Added test coverage for campaign leads pagination parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->