### PR TITLE
fix: initialize password toggles after dom ready

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -274,6 +274,14 @@ function initPasswordVisibilityToggle() {
     });
 }
 
+function initPasswordVisibilityToggleWhenReady() {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initPasswordVisibilityToggle, { once: true });
+    } else {
+        initPasswordVisibilityToggle();
+    }
+}
+
 // ==========================================
 // FOOTER ATTRIBUTION
 // ==========================================
@@ -367,7 +375,6 @@ async function initAppShell() {
     appShellInitialized = true;
 
     initThemeToggle();
-    initPasswordVisibilityToggle();
     injectSessionTimeoutModal();
 
     document.addEventListener('click', (event) => {
@@ -464,6 +471,8 @@ if (document.readyState === 'loading') {
 } else {
     initAppShell();
 }
+
+initPasswordVisibilityToggleWhenReady();
 
 // ==========================================
 // KEYBOARD SHORTCUTS


### PR DESCRIPTION
## What changed
- added a DOM-ready guard around password toggle initialization
- ensures the login and register eye buttons bind even when the module loads after `DOMContentLoaded`

## Why
- the password visibility toggle could fail to attach on the auth pages because the initializer missed the DOM event timing

## Validation
- `git diff --check`

Closes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password visibility toggle initialization to ensure reliable functionality across different page load scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->