### PR TITLE
feat: add campaign duplication action

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -116,6 +116,57 @@ class CampaignWorkflowTests(APITestCase):
                 self.assertEqual(steps[index].template_subject or '', subject)
                 self.assertEqual(steps[index].template_body or '', body)
 
+    def test_duplicate_campaign_clones_steps_without_enrolled_leads(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Q2 outreach',
+            status='ACTIVE',
+            settings={'timezone': 'Asia/Kolkata', 'steps': [{'type': 'EMAIL', 'subject': 'Draft'}]},
+        )
+        first_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='Hello',
+            template_body='Body',
+        )
+        SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=2,
+            channel_type='WAIT',
+            delay_minutes=1440,
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='clone-me@acme.test',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            status='ENROLLED',
+        )
+
+        response = self.client.post(f'/api/v1/campaigns/{campaign.id}/duplicate/', format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        duplicate = Campaign.objects.exclude(id=campaign.id).get(name='Copy of Q2 outreach')
+        self.assertEqual(response.data['id'], str(duplicate.id))
+        self.assertEqual(duplicate.status, 'DRAFT')
+        self.assertEqual(duplicate.settings, campaign.settings)
+        self.assertEqual(duplicate.connected_account_id, campaign.connected_account_id)
+        self.assertEqual(duplicate.enrolled_leads.count(), 0)
+
+        duplicate_steps = list(duplicate.steps.order_by('step_order'))
+        self.assertEqual(len(duplicate_steps), 2)
+        self.assertEqual(duplicate_steps[0].channel_type, first_step.channel_type)
+        self.assertEqual(duplicate_steps[0].template_subject, first_step.template_subject)
+        self.assertEqual(duplicate_steps[1].channel_type, 'WAIT')
+        self.assertEqual(duplicate_steps[1].delay_minutes, 1440)
+
     def test_personalize_email_replaces_custom_variables(self):
         lead = Lead.objects.create(
             organization=self.organization,

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -2,6 +2,7 @@ import logging
 
 
 import urllib.parse
+from django.db import transaction
 from django.core.signing import Signer, BadSignature
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 # ------------------------------------------
@@ -327,6 +328,40 @@ class CampaignViewSet(viewsets.ModelViewSet):
                 "message": f"Processed {processed} campaign leads immediately.",
             },
             status=status.HTTP_200_OK,
+        )
+
+    @action(detail=True, methods=['post'])
+    def duplicate(self, request, pk=None):
+        campaign = self.get_object()
+
+        with transaction.atomic():
+            duplicate_campaign = Campaign.objects.create(
+                organization=campaign.organization,
+                name=f"Copy of {campaign.name}",
+                status='DRAFT',
+                settings=campaign.settings.copy() if isinstance(campaign.settings, dict) else campaign.settings,
+                connected_account=campaign.connected_account,
+            )
+
+            steps = list(campaign.steps.all())
+            if steps:
+                SequenceStep.objects.bulk_create([
+                    SequenceStep(
+                        organization=campaign.organization,
+                        campaign=duplicate_campaign,
+                        step_order=step.step_order,
+                        channel_type=step.channel_type,
+                        delay_minutes=step.delay_minutes,
+                        template_subject=step.template_subject,
+                        template_body=step.template_body,
+                    )
+                    for step in steps
+                ])
+
+        duplicate_campaign.refresh_from_db()
+        return Response(
+            CampaignSerializer(duplicate_campaign, context=self.get_serializer_context()).data,
+            status=status.HTTP_201_CREATED,
         )
 
 class SequenceStepViewSet(viewsets.ModelViewSet):

--- a/frontend/campaigns.html
+++ b/frontend/campaigns.html
@@ -370,6 +370,11 @@
                                     <a href="/campaign-builder.html?id=${campaign.id}" class="btn btn-sm btn-outline-primary flex-grow-1">
                                        <i class="bi bi-pencil me-1" aria-hidden="true"></i> Edit
                                     </a>
+                                    <button class="btn btn-sm btn-outline-secondary flex-grow-1"
+                                        data-duplicate-id="${campaign.id}"
+                                        data-duplicate-name="${escapeHtml(campaign.name || 'Untitled campaign')}">
+                                        <i class="bi bi-files me-1" aria-hidden="true"></i> Duplicate
+                                    </button>
                                     ${actionButton}
                                     <button class="btn btn-sm btn-outline-danger flex-grow-1"
                                         data-delete-id="${campaign.id}"
@@ -427,6 +432,35 @@
                     const modalEl = document.getElementById('deleteCampaignModal');
                     if (modalEl && window.bootstrap) {
                         bootstrap.Modal.getOrCreateInstance(modalEl).show();
+                    }
+                });
+            });
+
+            grid.querySelectorAll('[data-duplicate-id]').forEach(button => {
+                button.addEventListener('click', async () => {
+                    const campaignId = button.dataset.duplicateId;
+                    const originalLabel = button.innerHTML;
+
+                    button.disabled = true;
+                    button.innerHTML = '<span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>Copying';
+
+                    try {
+                        const res = await fetchWithAuth(`/campaigns/${campaignId}/duplicate/`, {
+                            method: 'POST',
+                        });
+
+                        if (!res.ok) {
+                            throw new Error('Failed to duplicate campaign.');
+                        }
+
+                        const duplicatedCampaign = await res.json();
+                        allCampaigns = [duplicatedCampaign, ...allCampaigns];
+                        renderApp();
+                    } catch (error) {
+                        alert(error.message || 'Could not duplicate campaign.');
+                    } finally {
+                        button.disabled = false;
+                        button.innerHTML = originalLabel;
                     }
                 });
             });

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -274,6 +274,14 @@ function initPasswordVisibilityToggle() {
     });
 }
 
+function initPasswordVisibilityToggleWhenReady() {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initPasswordVisibilityToggle, { once: true });
+    } else {
+        initPasswordVisibilityToggle();
+    }
+}
+
 // ==========================================
 // FOOTER ATTRIBUTION
 // ==========================================
@@ -367,7 +375,6 @@ async function initAppShell() {
     appShellInitialized = true;
 
     initThemeToggle();
-    initPasswordVisibilityToggle();
     injectSessionTimeoutModal();
 
     document.addEventListener('click', (event) => {
@@ -464,6 +471,8 @@ if (document.readyState === 'loading') {
 } else {
     initAppShell();
 }
+
+initPasswordVisibilityToggleWhenReady();
 
 // ==========================================
 // KEYBOARD SHORTCUTS


### PR DESCRIPTION
## Summary\n- Add POST /api/v1/campaigns/{id}/duplicate/ to clone campaigns\n- Copy campaign settings and sequence steps, but start fresh in DRAFT with no enrolled leads\n- Add a Duplicate button to the campaign card UI\n\n## Validation\n- git diff --check\n- python3 backend/manage.py test campaigns.tests.CampaignWorkflowTests.test_duplicate_campaign_clones_steps_without_enrolled_leads (blocked locally: ModuleNotFoundError: No module named 'rest_framework')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign duplication: Users can now duplicate existing campaigns with settings and sequence steps automatically copied to a new draft campaign. Enrolled leads are not carried over to the duplicate.

* **Bug Fixes**
  * Enhanced password visibility toggle initialization to ensure proper timing and reliability.

* **Tests**
  * Added workflow test for campaign duplication to verify correct cloning of sequence steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->