### PR TITLE
fix: hide sensitive organization fields

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -5,7 +5,7 @@ from tenants.models import Organization
 class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization
-        fields = '__all__'
+        fields = ['id', 'name', 'billing_plan', 'created_at', 'enable_ai_personalization']
 
 class UserSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer(read_only=True)

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -55,6 +55,8 @@ class AuthMeViewTests(APITestCase):
         self.user.refresh_from_db()
         self.assertEqual(self.organization.name, 'Org After')
         self.assertTrue(self.user.check_password('EvenStronger123!'))
+        self.assertNotIn('gemini_api_key', response.data['organization'])
+        self.assertNotIn('enable_ai_personalization', response.data['organization'])
 
     def test_patch_me_rejects_empty_payload(self):
         response = self.client.patch('/api/v1/auth/me/', {}, format='json')


### PR DESCRIPTION
## Summary\n- Replace OrganizationSerializer fields='__all__' with an explicit safe field list\n- Keep gemini_api_key out of /api/v1/auth/me/ responses\n- Add a regression assertion to verify the nested organization payload stays scrubbed\n\n## Validation\n- git diff --check\n- python3 backend/manage.py test users.tests.AuthMeViewTests.test_patch_me_updates_password_and_organization (blocked locally: ModuleNotFoundError: No module named 'rest_framework')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization API responses now exclude sensitive fields, returning only essential information including ID, name, billing plan, and creation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->