### PR TITLE
fix: load allowed hosts from env

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -48,9 +48,21 @@ def _normalize_google_redirect_uri(raw_uri: str, backend_base_url: str) -> str:
     # Canonicalize callback path so Google/login/token-exchange always match.
     return f'{scheme}://{host}/api/v1/auth/google/callback'
 
+
+def _parse_allowed_hosts(raw_hosts: str, debug: bool) -> list[str]:
+    parsed_hosts = [host.strip() for host in (raw_hosts or '').split(',') if host.strip()]
+    if not parsed_hosts:
+        return ['*'] if debug else ['localhost', '127.0.0.1']
+
+    if debug:
+        return parsed_hosts
+
+    filtered_hosts = [host for host in parsed_hosts if host != '*']
+    return filtered_hosts or ['localhost', '127.0.0.1']
+
 SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-fallback-key-change-me')
 DEBUG = os.getenv('DEBUG', 'True').lower() in ('true', '1', 'yes')
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = _parse_allowed_hosts(os.getenv('ALLOWED_HOSTS', ''), DEBUG)
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",

--- a/backend/tenants/tests.py
+++ b/backend/tenants/tests.py
@@ -1,3 +1,26 @@
 from django.test import TestCase
 
+from backend.settings import _parse_allowed_hosts
+
 # Create your tests here.
+
+
+class AllowedHostsSettingsTests(TestCase):
+    def test_parse_allowed_hosts_defaults_to_local_hosts_outside_debug(self):
+        self.assertEqual(
+            _parse_allowed_hosts('', debug=False),
+            ['localhost', '127.0.0.1'],
+        )
+
+    def test_parse_allowed_hosts_allows_wildcard_only_in_debug(self):
+        self.assertEqual(_parse_allowed_hosts('*', debug=True), ['*'])
+        self.assertEqual(
+            _parse_allowed_hosts('*', debug=False),
+            ['localhost', '127.0.0.1'],
+        )
+
+    def test_parse_allowed_hosts_trims_and_preserves_comma_separated_hosts(self):
+        self.assertEqual(
+            _parse_allowed_hosts(' example.com , api.example.com ', debug=False),
+            ['example.com', 'api.example.com'],
+        )


### PR DESCRIPTION
## Summary\n- Replace ALLOWED_HOSTS = ['*'] with env-driven parsing\n- Default to localhost/127.0.0.1 outside debug\n- Keep wildcard hosts only for debug/local use\n- Add focused helper tests for the parsing behavior\n\n## Validation\n- git diff --check\n- PYTHONPATH=backend python3 - <<'PY'\nfrom backend.settings import _parse_allowed_hosts\nassert _parse_allowed_hosts('', False) == ['localhost', '127.0.0.1']\nassert _parse_allowed_hosts('*', True) == ['*']\nassert _parse_allowed_hosts('*', False) == ['localhost', '127.0.0.1']\nassert _parse_allowed_hosts(' example.com , api.example.com ', False) == ['example.com', 'api.example.com']\nPY\n- gh issue edit 319 --add-assignee saurabhhhcodes (blocked by repo permissions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host allowlist security by removing hardcoded wildcard acceptance and implementing environment-based configuration with safer defaults (localhost and 127.0.0.1).

* **Tests**
  * Added tests for host configuration parsing and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->