### PR TITLE
fix: gate cors wildcard by debug

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -48,6 +48,10 @@ def _normalize_google_redirect_uri(raw_uri: str, backend_base_url: str) -> str:
     # Canonicalize callback path so Google/login/token-exchange always match.
     return f'{scheme}://{host}/api/v1/auth/google/callback'
 
+
+def _allow_all_cors_origins(debug: bool) -> bool:
+    return bool(debug)
+
 SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-fallback-key-change-me')
 DEBUG = os.getenv('DEBUG', 'True').lower() in ('true', '1', 'yes')
 ALLOWED_HOSTS = ['*']
@@ -172,7 +176,7 @@ SIMPLE_JWT = {
 }
 
 # Allow all origins in development
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_ALL_ORIGINS = _allow_all_cors_origins(DEBUG)
 
 # Gemini API Key
 GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', _read_local_env_value('GEMINI_API_KEY', ''))

--- a/backend/tenants/tests.py
+++ b/backend/tenants/tests.py
@@ -1,3 +1,9 @@
 from django.test import TestCase
 
-# Create your tests here.
+from backend.settings import _allow_all_cors_origins
+
+
+class CorsSettingsTests(TestCase):
+    def test_allow_all_cors_origins_matches_debug_mode(self):
+        self.assertTrue(_allow_all_cors_origins(True))
+        self.assertFalse(_allow_all_cors_origins(False))


### PR DESCRIPTION
## Summary\n- Replace CORS_ALLOW_ALL_ORIGINS = True with a debug-aware helper\n- Keep wildcard CORS only for local development\n- Add a focused regression test for the helper\n\n## Validation\n- git diff --check\n- PYTHONPATH=backend python3 - <<'PY'\nfrom backend.settings import _allow_all_cors_origins\nassert _allow_all_cors_origins(True) is True\nassert _allow_all_cors_origins(False) is False\nPY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-origin requests now properly respect development vs. production environments.

* **Tests**
  * Added tests for cross-origin request configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->