### PR TITLE
fix: eager load dashboard recent activity

### DIFF
--- a/backend/campaigns/migrations/0010_merge_0009.py
+++ b/backend/campaigns/migrations/0010_merge_0009.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("campaigns", "0009_campaign_cached_counters"),
+        ("campaigns", "0009_campaignlead_bounce_metadata"),
+    ]
+
+    operations = []

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -1,13 +1,15 @@
-import logging from datetime 
-import timedelta from celery 
-import shared_task from django.conf 
-import settings as django_settings from django.utils 
-import timezone from .ai 
-import _apply_merge_tags, personalize_email from .gmail_service
-import build_unsubscribe_url, check_for_replies, send_gmail from .sms_service 
-import send_sms, initiate_call from .models 
-import CampaignLead, SequenceStep from leads.models 
-import BlockedDomain, normalize_domain
+import logging
+from datetime import timedelta
+
+from celery import shared_task
+from django.conf import settings as django_settings
+from django.utils import timezone
+
+from .ai import _apply_merge_tags, personalize_email
+from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
+from .sms_service import send_sms, initiate_call
+from .models import CampaignLead, SequenceStep
+from leads.models import BlockedDomain, normalize_domain
 
 
 import urllib.parse

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1271,16 +1271,17 @@ class CampaignWorkflowTests(APITestCase):
             name='Other Corp Campaign',
             status='ACTIVE',
         )
-        other_lead = Lead.objects.create(
-            organization=org2,
-            email='otherlead@othercorp.test',
-        )
-        CampaignLead.objects.create(
-            organization=org2,
-            campaign=other_campaign,
-            lead=other_lead,
-            status='REPLIED',
-        )
+        for index in range(5):
+            other_lead = Lead.objects.create(
+                organization=org2,
+                email=f'otherlead{index}@othercorp.test',
+            )
+            CampaignLead.objects.create(
+                organization=org2,
+                campaign=other_campaign,
+                lead=other_lead,
+                status='REPLIED',
+            )
 
         # Acme user should see zero data (org2's data must not leak)
         response = self.client.get('/api/v1/analytics/dashboard/')
@@ -1293,11 +1294,13 @@ class CampaignWorkflowTests(APITestCase):
 
         # org2 user should only see their own data
         self.client.force_authenticate(other_user)
-        response = self.client.get('/api/v1/analytics/dashboard/')
+        with self.assertNumQueries(8):
+            response = self.client.get('/api/v1/analytics/dashboard/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['total_leads'], 1)
+        self.assertEqual(response.data['total_leads'], 5)
         self.assertEqual(response.data['active_campaigns'], 1)
-        self.assertEqual(response.data['replied'], 1)
+        self.assertEqual(response.data['replied'], 5)
+        self.assertEqual(len(response.data['recent_activity']), 5)
 
     def test_dashboard_analytics_requires_authentication(self):
         self.client.force_authenticate(user=None)

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -600,7 +600,7 @@ class DashboardAnalyticsView(APIView):
 
         # ── Recent activity (real data) ──
         recent = []
-        for cl in CampaignLead.objects.filter(organization=org).order_by('-updated_at')[:10]:
+        for cl in CampaignLead.objects.filter(organization=org).select_related('lead', 'campaign').order_by('-updated_at')[:10]:
             action = cl.status.lower()
             lead_name = cl.lead.email if cl.lead else 'Unknown'
             recent.append({


### PR DESCRIPTION
## What changed
- Eager-load `lead` and `campaign` when building dashboard recent activity.
- Tightened the dashboard tenant-isolation test to cover the recent-activity result shape and the query budget.
- Added a merge migration so the campaigns migration graph stays linear for test runs.
- Normalized the campaigns task imports so the module loads cleanly in tests.

## Why
The dashboard analytics path was doing extra work for each recent activity row. This patch removes the N+1 pattern and keeps the test coverage aligned with the actual dashboard response.

## Validation
- `git diff --check`
- `PYTHONPATH=/Users/saurabhkumarbajpaiai/Documents/Codex/2026-05-15/LeadOrbit/backend /tmp/leadorbit-venv/bin/python3 /Users/saurabhkumarbajpaiai/Documents/Codex/2026-05-15/LeadOrbit/backend/manage.py test campaigns.tests.CampaignWorkflowTests.test_dashboard_analytics_isolates_data_by_tenant -v 2`
