### PR TITLE
hide organization api keys

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -5,7 +5,7 @@ from tenants.models import Organization
 class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization
-        fields = '__all__'
+        fields = ['id', 'name', 'billing_plan', 'created_at', 'enable_ai_personalization']
 
 class UserSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer(read_only=True)

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -55,6 +55,16 @@ class AuthMeViewTests(APITestCase):
         self.user.refresh_from_db()
         self.assertEqual(self.organization.name, 'Org After')
         self.assertTrue(self.user.check_password('EvenStronger123!'))
+        self.assertNotIn('gemini_api_key', response.data['organization'])
+
+    def test_me_response_does_not_expose_organization_api_key(self):
+        self.organization.gemini_api_key = 'super-secret-key'
+        self.organization.save(update_fields=['gemini_api_key'])
+
+        response = self.client.get('/api/v1/auth/me/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn('gemini_api_key', response.data['organization'])
 
     def test_patch_me_rejects_empty_payload(self):
         response = self.client.patch('/api/v1/auth/me/', {}, format='json')


### PR DESCRIPTION
Narrow the organization serializer so `/api/v1/auth/me/` no longer exposes sensitive organization fields like `gemini_api_key`.

- Issue: #326
- Replaced `fields = '__all__'` with an explicit allowlist in `OrganizationSerializer`
- Added a regression test that confirms `gemini_api_key` is not present in the auth/me response payload
- Verified the serializer field list directly in Django shell and confirmed the key is excluded

Validation:
- `PYTHONPATH=/tmp/leadorbit-330/backend /tmp/leadorbit-venv-312/bin/python - <<'PY' ... django.setup() ... OrganizationSerializer().fields ... PY`
- `PYTHONPATH=/tmp/leadorbit-330/backend /tmp/leadorbit-venv-312/bin/python /tmp/leadorbit-330/backend/manage.py check`
- `git diff --check`

Note: the broader users test command is currently blocked by an existing campaigns migration-graph conflict (`0009_campaign_cached_counters` vs `0009_campaignlead_bounce_metadata`).
