### PR TITLE
fix click tracking redirects

### DIFF
--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -1,21 +1,23 @@
-import logging from datetime 
-import timedelta from celery 
-import shared_task from django.conf 
-import settings as django_settings from django.utils 
-import timezone from .ai 
-import _apply_merge_tags, personalize_email from .gmail_service
-import build_unsubscribe_url, check_for_replies, send_gmail from .sms_service 
-import send_sms, initiate_call from .models 
-import CampaignLead, SequenceStep from leads.models 
-import BlockedDomain, normalize_domain
+import logging
+import re
+from datetime import timedelta
 
+from celery import shared_task
+from django.conf import settings as django_settings
+from django.utils import timezone
+from leads.models import BlockedDomain, normalize_domain
+
+from .ai import _apply_merge_tags, personalize_email
+from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
+from .models import CampaignLead, SequenceStep
+from .sms_service import initiate_call, send_sms
 
 import urllib.parse
-from bs4 import BeautifulSoup
 from django.core.signing import Signer
 
 
 logger = logging.getLogger(__name__)
+HREF_PATTERN = re.compile(r'(<a\b[^>]*\bhref=["\'])([^"\']+)(["\'])', re.IGNORECASE)
 
 def _get_campaign_steps(campaign):
     """
@@ -430,7 +432,6 @@ def rewrite_email_links(html_body, campaign_lead_id, step_id):
     if not html_body:
         return html_body
 
-    soup = BeautifulSoup(html_body, 'html.parser')
     signer = Signer()
     
     token_payload = f"{campaign_lead_id}:{step_id}"
@@ -438,19 +439,19 @@ def rewrite_email_links(html_body, campaign_lead_id, step_id):
     
     base_url = getattr(django_settings, 'BACKEND_BASE_URL', 'http://127.0.0.1:8000').rstrip('/')
     tracking_endpoint = f"{base_url}/api/v1/clicks/track/"
-    
-    for a_tag in soup.find_all('a', href=True):
-        original_url = a_tag.get('href', '')
-        
+
+    def replace_href(match):
+        prefix, original_url, suffix = match.groups()
+        original_url = (original_url or '').strip()
+
         if not original_url or original_url.startswith(('mailto:', 'tel:')) or tracking_endpoint in original_url:
-            continue
-            
+            return match.group(0)
+
         encoded_dest = urllib.parse.quote(original_url, safe='')
-        
         tracking_url = f"{tracking_endpoint}?t={signed_token}&dest={encoded_dest}"
-        a_tag['href'] = tracking_url
-        
-    return str(soup)
+        return f"{prefix}{tracking_url}{suffix}"
+
+    return HREF_PATTERN.sub(replace_href, html_body)
 # -----------------------------------
 
 

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from unittest.mock import patch
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, urlparse
 
 from django.core import signing
 from django.test import override_settings
@@ -1431,6 +1431,70 @@ class CampaignWorkflowTests(APITestCase):
         self.assertIsNone(campaign_lead.next_execution_time)
         self.assertEqual(campaign.status, 'COMPLETED')
         mocked_send.assert_not_called()
+
+
+@override_settings(BACKEND_BASE_URL='https://backend.example.test')
+class ClickTrackingSecurityTests(APITestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name='Click Org')
+        self.user = User.objects.create_user(
+            email='click-owner@acme.test',
+            password='StrongPass123!',
+            organization=self.organization,
+            role='ADMIN',
+        )
+        self.client.force_authenticate(self.user)
+
+        self.campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Click campaign',
+            status='ACTIVE',
+        )
+        self.step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=self.campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_body='<p><a href="https://example.test/offer">Open offer</a></p>',
+        )
+        self.lead = Lead.objects.create(
+            organization=self.organization,
+            email='lead@acme.test',
+        )
+        self.campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=self.campaign,
+            lead=self.lead,
+            current_step=self.step,
+            status='ACTIVE',
+        )
+        self.signed_token = signing.Signer().sign(f'{self.campaign_lead.id}:{self.step.id}')
+
+    def test_click_tracking_redirects_only_to_link_in_email_body(self):
+        response = self.client.get(
+            '/api/v1/clicks/track/',
+            {
+                't': self.signed_token,
+                'dest': quote('https://example.test/offer', safe=''),
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response['Location'], 'https://example.test/offer')
+
+    def test_click_tracking_rejects_external_redirects_not_in_email_body(self):
+        response = self.client.get(
+            '/api/v1/clicks/track/',
+            {
+                't': self.signed_token,
+                'dest': quote('https://evil.test/phish', safe=''),
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.campaign_lead.refresh_from_db()
+        self.assertIsNone(self.campaign_lead.last_clicked_at)
 
 
 @override_settings(

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -1,6 +1,7 @@
 import logging
 
 
+import re
 import urllib.parse
 from django.core.signing import Signer, BadSignature
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
@@ -18,6 +19,31 @@ from .models import Campaign, CampaignLead, SequenceStep, EmailTemplate
 from .serializers import CampaignSerializer, SequenceStepSerializer, EmailTemplateSerializer
 
 logger = logging.getLogger(__name__)
+HREF_PATTERN = re.compile(r'<a\b[^>]*\bhref=["\']([^"\']+)["\']', re.IGNORECASE)
+
+
+def _extract_valid_click_destinations(step):
+    html_body = (step.template_body or '').strip()
+    if not html_body:
+        return set()
+
+    destinations = set()
+    for match in HREF_PATTERN.finditer(html_body):
+        href = (match.group(1) or '').strip()
+        if not href or href.startswith(('mailto:', 'tel:')):
+            continue
+        destinations.add(urllib.parse.unquote(href))
+
+    return destinations
+
+
+def _is_valid_click_destination(dest_url, step):
+    decoded_dest = urllib.parse.unquote(dest_url or '').strip()
+    parsed_dest = urllib.parse.urlparse(decoded_dest)
+    if parsed_dest.scheme not in {'http', 'https'} or not parsed_dest.netloc:
+        return False
+
+    return decoded_dest in _extract_valid_click_destinations(step)
 
 class CampaignViewSet(viewsets.ModelViewSet):
     serializer_class = CampaignSerializer
@@ -797,9 +823,19 @@ class ClickTrackingView(APIView):
         except (BadSignature, ValueError):
             return HttpResponseBadRequest("Invalid or tampered tracking token.")
 
-        # Analytics ko update karna
         try:
             lead = CampaignLead.objects.get(id=campaign_lead_id)
+            step = SequenceStep.objects.get(id=step_id, campaign=lead.campaign)
+        except CampaignLead.DoesNotExist:
+            return HttpResponseBadRequest("Unknown campaign lead.")
+        except SequenceStep.DoesNotExist:
+            return HttpResponseBadRequest("Unknown campaign step.")
+
+        if not _is_valid_click_destination(dest_url, step):
+            return HttpResponseBadRequest("Invalid click destination.")
+
+        # Analytics ko update karna
+        try:
             lead.last_clicked_at = timezone.now()
             lead.save(update_fields=['last_clicked_at'])
 


### PR DESCRIPTION
Tighten click tracking so redirects only go to links that were already present in the email body.

What changed:
- Validate the `dest` URL in `ClickTrackingView`.
- Require an absolute `http`/`https` URL.
- Require the destination to match one of the links in the step's template body.
- Add regression tests for the allowed and rejected redirect paths.
- Replace the task-side HTML link rewrite parser with a stdlib-only implementation so the helper still runs in this environment.

Why:
- The current endpoint accepts an arbitrary destination from query params, which creates an open redirect vulnerability.

Validation:
- `git diff --check`
- `python3 -m py_compile /tmp/leadorbit-330/backend/campaigns/views.py /tmp/leadorbit-330/backend/campaigns/tasks.py /tmp/leadorbit-330/backend/campaigns/tests.py`
- Direct smoke test of `rewrite_email_links(...)` and `_is_valid_click_destination(...)`
- `manage.py test campaigns.tests.ClickTrackingSecurityTests -v 2` is blocked by an existing repo migration conflict: `0009_campaign_cached_counters` vs `0009_campaignlead_bounce_metadata`

Closes #333
