### PR TITLE
fix: prefetch lead tags in list queries

### DIFF
--- a/backend/leads/serializers.py
+++ b/backend/leads/serializers.py
@@ -30,7 +30,8 @@ class LeadSerializer(serializers.ModelSerializer):
         read_only_fields = ['organization', 'score']
 
     def get_tags(self, obj):
-        tags = Tag.objects.filter(tagged_leads__lead=obj)
+        lead_tags = list(obj.lead_tags.all())
+        tags = [lead_tag.tag for lead_tag in lead_tags]
         return TagSerializer(tags, many=True).data
 
     def _set_tags(self, lead, tag_ids):

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -140,6 +140,20 @@ class LeadIsolationAPITests(APITestCase):
         self.assertIn(self.lead_a.email, emails)
         self.assertNotIn(self.lead_b.email, emails)
 
+    def test_list_leads_uses_prefetched_tags(self):
+        hot = Tag.objects.create(organization=self.org_a, name='Hot')
+        archived = Tag.objects.create(organization=self.org_b, name='Archived')
+        LeadTag.objects.create(lead=self.lead_a, tag=hot, organization=self.org_a)
+        LeadTag.objects.create(lead=self.lead_b, tag=archived, organization=self.org_b)
+
+        self.client.force_authenticate(self.user_a)
+        with self.assertNumQueries(3):
+            response = self.client.get('/api/v1/leads/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['tags'][0]['name'], 'Hot')
+
     def test_create_lead_attaches_to_current_users_organization(self):
         self.client.force_authenticate(self.user_b)
         response = self.client.post(

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -78,7 +78,7 @@ class LeadViewSet(viewsets.ModelViewSet):
                 | Q(company__icontains=search)
             )
 
-        return qs.distinct()
+        return qs.prefetch_related('lead_tags__tag').distinct()
 
     def perform_create(self, serializer):
         serializer.save(organization=self.request.user.organization)


### PR DESCRIPTION
## Summary
- prefetch lead tags in the list query to remove the serializer N+1 pattern
- teach the serializer to read tag objects from the prefetched relation
- add a query-count regression test for lead listings

## Validation
- git diff --check
- python3 -m py_compile backend/leads/serializers.py backend/leads/views.py backend/leads/tests.py

Closes #328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized retrieval of tags associated with lead records.

* **Tests**
  * Added test coverage for lead API endpoint tag retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->