### PR TITLE
fix: eager load dashboard recent activity

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1271,16 +1271,17 @@ class CampaignWorkflowTests(APITestCase):
             name='Other Corp Campaign',
             status='ACTIVE',
         )
-        other_lead = Lead.objects.create(
-            organization=org2,
-            email='otherlead@othercorp.test',
-        )
-        CampaignLead.objects.create(
-            organization=org2,
-            campaign=other_campaign,
-            lead=other_lead,
-            status='REPLIED',
-        )
+        for index in range(5):
+            other_lead = Lead.objects.create(
+                organization=org2,
+                email=f'otherlead{index}@othercorp.test',
+            )
+            CampaignLead.objects.create(
+                organization=org2,
+                campaign=other_campaign,
+                lead=other_lead,
+                status='REPLIED',
+            )
 
         # Acme user should see zero data (org2's data must not leak)
         response = self.client.get('/api/v1/analytics/dashboard/')
@@ -1293,11 +1294,13 @@ class CampaignWorkflowTests(APITestCase):
 
         # org2 user should only see their own data
         self.client.force_authenticate(other_user)
-        response = self.client.get('/api/v1/analytics/dashboard/')
+        with self.assertNumQueries(8):
+            response = self.client.get('/api/v1/analytics/dashboard/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['total_leads'], 1)
+        self.assertEqual(response.data['total_leads'], 5)
         self.assertEqual(response.data['active_campaigns'], 1)
-        self.assertEqual(response.data['replied'], 1)
+        self.assertEqual(response.data['replied'], 5)
+        self.assertEqual(len(response.data['recent_activity']), 5)
 
     def test_dashboard_analytics_requires_authentication(self):
         self.client.force_authenticate(user=None)

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -600,7 +600,7 @@ class DashboardAnalyticsView(APIView):
 
         # ── Recent activity (real data) ──
         recent = []
-        for cl in CampaignLead.objects.filter(organization=org).order_by('-updated_at')[:10]:
+        for cl in CampaignLead.objects.filter(organization=org).select_related('lead', 'campaign').order_by('-updated_at')[:10]:
             action = cl.status.lower()
             lead_name = cl.lead.email if cl.lead else 'Unknown'
             recent.append({


### PR DESCRIPTION
## Summary
- add select_related for lead and campaign on the dashboard recent-activity query
- add a query-count regression test for the dashboard analytics endpoint

## Validation
- git diff --check
- python3 -m py_compile backend/campaigns/views.py backend/campaigns/tests.py

Closes #330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized dashboard analytics queries to significantly improve overall performance and reduce total database load in multi-tenant deployments

* **Tests**
  * Expanded test coverage for dashboard analytics to thoroughly verify proper data isolation between multiple tenant accounts
  * Integrated query performance validation into the test suite to ensure ongoing efficiency and prevent future performance regressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->