### PR TITLE
fix CSV import upload size validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 DEBUG=False
 SECRET_KEY="django-insecure-e*%&ob9vkj!8$11wskk0wj7sm7-ij3xlb2f3wfr3ny0w(5cijh"
+MAX_CSV_UPLOAD_SIZE=10485760
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -190,6 +190,9 @@ ENABLE_AUTO_REPLY_DETECTION = os.getenv(
 # Limit synchronous processing inside launch API calls to keep requests responsive.
 LAUNCH_IMMEDIATE_PASSES = int(os.getenv('LAUNCH_IMMEDIATE_PASSES', '1' if DEBUG else '0'))
 
+# CSV import safety cap to avoid loading oversized files into memory.
+MAX_CSV_UPLOAD_SIZE = int(os.getenv('MAX_CSV_UPLOAD_SIZE', str(10 * 1024 * 1024)))
+
 # Email backend (console for dev)
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -1,4 +1,5 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -250,6 +251,25 @@ class LeadIsolationAPITests(APITestCase):
         self.assertIn('results', response.data)
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['filename'], 'orga.csv')
+
+    @override_settings(MAX_CSV_UPLOAD_SIZE=10)
+    def test_import_csv_rejects_oversized_upload_before_reading(self):
+        self.client.force_authenticate(self.manager_a)
+        oversized_file = SimpleUploadedFile(
+            'too-big.csv',
+            b'a' * 11,
+            content_type='text/csv',
+        )
+
+        response = self.client.post(
+            '/api/v1/leads/import_csv/',
+            {'file': oversized_file},
+            format='multipart',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('exceeds the maximum allowed size', response.data['error'])
+        self.assertFalse(LeadImportJob.objects.filter(organization=self.org_a).exists())
 
 
 # ── New tests for Issue #244 ───────────────────────────────────────────────────

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import Q
 from rest_framework import viewsets, parsers, status
 from rest_framework.pagination import PageNumberPagination
@@ -96,6 +97,13 @@ class LeadViewSet(viewsets.ModelViewSet):
         file_obj = request.FILES.get('file')
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
+
+        max_upload_size = settings.MAX_CSV_UPLOAD_SIZE
+        if file_obj.size > max_upload_size:
+            return Response(
+                {"error": f"CSV file exceeds the maximum allowed size of {max_upload_size} bytes."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         job = LeadImportJob.objects.create(
             organization=request.user.organization,


### PR DESCRIPTION
## What changed

- Added a `MAX_CSV_UPLOAD_SIZE` setting and wired it into the lead CSV import endpoint.
- Rejects oversized uploads before reading them into memory.
- Added a regression test that confirms oversized CSV uploads return HTTP 400 and do not create an import job.

## Related issue

- Closes #327

## Validation

- `python3 -m py_compile /tmp/leadorbit-330/backend/leads/views.py /tmp/leadorbit-330/backend/leads/tests.py`
- `git -C /tmp/leadorbit-330 diff --check`
- Full Django test execution is blocked in the current shell because the repository requires Django 5 and this machine only has Python 3.9 installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a configurable maximum file size limit for CSV uploads (default: 10 MB) to prevent oversized files from being processed, with user-friendly error messages for rejected uploads.

* **Tests**
  * Added comprehensive test coverage for CSV upload size validation, ensuring oversized files are properly rejected with appropriate error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->