### PR TITLE
fix CORS allow-all only in debug

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -48,6 +48,10 @@ def _normalize_google_redirect_uri(raw_uri: str, backend_base_url: str) -> str:
     # Canonicalize callback path so Google/login/token-exchange always match.
     return f'{scheme}://{host}/api/v1/auth/google/callback'
 
+
+def _allow_all_cors_origins(debug: bool) -> bool:
+    return debug
+
 SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-fallback-key-change-me')
 DEBUG = os.getenv('DEBUG', 'True').lower() in ('true', '1', 'yes')
 ALLOWED_HOSTS = ['*']
@@ -171,8 +175,8 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
 }
 
-# Allow all origins in development
-CORS_ALLOW_ALL_ORIGINS = True
+# Allow all origins only in development.
+CORS_ALLOW_ALL_ORIGINS = _allow_all_cors_origins(DEBUG)
 
 # Gemini API Key
 GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', _read_local_env_value('GEMINI_API_KEY', ''))

--- a/backend/tenants/tests.py
+++ b/backend/tenants/tests.py
@@ -1,3 +1,31 @@
 from django.test import TestCase
 
-# Create your tests here.
+from backend.settings import _allow_all_cors_origins
+from backend.settings import _parse_allowed_hosts
+
+
+class AllowedHostsSettingsTests(TestCase):
+    def test_parse_allowed_hosts_defaults_to_local_hosts_outside_debug(self):
+        self.assertEqual(
+            _parse_allowed_hosts('', debug=False),
+            ['localhost', '127.0.0.1'],
+        )
+
+    def test_parse_allowed_hosts_allows_wildcard_only_in_debug(self):
+        self.assertEqual(_parse_allowed_hosts('*', debug=True), ['*'])
+        self.assertEqual(
+            _parse_allowed_hosts('*', debug=False),
+            ['localhost', '127.0.0.1'],
+        )
+
+    def test_parse_allowed_hosts_trims_and_preserves_comma_separated_hosts(self):
+        self.assertEqual(
+            _parse_allowed_hosts(' example.com , api.example.com ', debug=False),
+            ['example.com', 'api.example.com'],
+        )
+
+
+class CorsSettingsTests(TestCase):
+    def test_allow_all_cors_origins_only_in_debug(self):
+        self.assertTrue(_allow_all_cors_origins(True))
+        self.assertFalse(_allow_all_cors_origins(False))


### PR DESCRIPTION
## What changed

- Changed `CORS_ALLOW_ALL_ORIGINS` to follow `DEBUG` instead of always being enabled.
- Added a small settings helper plus regression tests for debug-only wildcard CORS behavior.

## Related issue

- Closes #318

## Validation

- `python3 -m py_compile /tmp/leadorbit-330/backend/backend/settings.py /tmp/leadorbit-330/backend/tenants/tests.py`
- `git -C /tmp/leadorbit-330 diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CORS configuration to restrict "allow all origins" to debug mode only, providing improved security for production deployments while maintaining flexibility during development.

* **Tests**
  * Added test coverage for configuration helpers, validating behavior across debug and production modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->