### PR TITLE
fix secret key handling in settings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,2 @@
 DEBUG=False
-SECRET_KEY="django-insecure-e*%&ob9vkj!8$11wskk0wj7sm7-ij3xlb2f3wfr3ny0w(5cijh"
-
+SECRET_KEY=change-me-in-local-env

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -4,7 +4,11 @@ Django settings for backend project.
 from pathlib import Path
 import os
 import re
+import secrets
+import sys
+import warnings
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 # Prefer local project .env values for local development runs.
@@ -48,8 +52,26 @@ def _normalize_google_redirect_uri(raw_uri: str, backend_base_url: str) -> str:
     # Canonicalize callback path so Google/login/token-exchange always match.
     return f'{scheme}://{host}/api/v1/auth/google/callback'
 
-SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-fallback-key-change-me')
-DEBUG = os.getenv('DEBUG', 'True').lower() in ('true', '1', 'yes')
+DEBUG = os.getenv('DEBUG', 'False').lower() in ('true', '1', 'yes')
+
+
+def _get_secret_key() -> str:
+    secret_key = os.getenv('SECRET_KEY') or _read_local_env_value('SECRET_KEY', '')
+    if secret_key:
+        return secret_key
+
+    if DEBUG or 'test' in sys.argv:
+        warnings.warn(
+            'SECRET_KEY is not set. Using a temporary development key; set SECRET_KEY in .env for persistence.',
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return secrets.token_urlsafe(64)
+
+    raise ImproperlyConfigured('SECRET_KEY must be set when DEBUG is False.')
+
+
+SECRET_KEY = _get_secret_key()
 ALLOWED_HOSTS = ['*']
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",

--- a/backend/tenants/tests.py
+++ b/backend/tenants/tests.py
@@ -1,3 +1,27 @@
+from unittest.mock import patch
+
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
-# Create your tests here.
+import backend.settings as project_settings
+
+
+class SettingsTests(TestCase):
+    def test_secret_key_falls_back_to_temporary_key_in_debug(self):
+        with patch.object(project_settings, 'DEBUG', True):
+            with patch.dict('backend.settings.os.environ', {}, clear=True):
+                with patch('backend.settings._read_local_env_value', return_value=''):
+                    with self.assertWarns(RuntimeWarning) as warning:
+                        secret_key = project_settings._get_secret_key()
+
+        self.assertTrue(secret_key)
+        self.assertNotEqual(secret_key, 'change-me-in-local-env')
+        self.assertIn('SECRET_KEY is not set', str(warning.warning))
+
+    def test_secret_key_requires_configuration_outside_debug(self):
+        with patch.object(project_settings, 'DEBUG', False):
+            with patch.object(project_settings.sys, 'argv', ['manage.py', 'runserver']):
+                with patch.dict('backend.settings.os.environ', {}, clear=True):
+                    with patch('backend.settings._read_local_env_value', return_value=''):
+                        with self.assertRaisesMessage(ImproperlyConfigured, 'SECRET_KEY must be set when DEBUG is False.'):
+                            project_settings._get_secret_key()


### PR DESCRIPTION
Closes #281\n\n- Load SECRET_KEY from environment or local .env when available\n- Generate a temporary key only for development or test runs, with a warning\n- Fail fast outside dev/test if SECRET_KEY is missing\n- Replace the example secret in backend/.env.example\n- Add regression coverage in tenants tests\n\nValidation:\n- python3 -m py_compile backend/backend/settings.py backend/tenants/tests.py\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables now fully supported for DEBUG and SECRET_KEY configuration.
  * DEBUG mode defaults to False, enhancing production security.
  * SECRET_KEY validation improved with environment-aware configuration handling.

* **Tests**
  * Added tests covering configuration behavior across different deployment and environment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->