### PR TITLE
fix campaign leads pagination parameters

### DIFF
--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1121,6 +1121,65 @@ class CampaignWorkflowTests(APITestCase):
         campaign.refresh_from_db()
         self.assertEqual(campaign.status, 'ACTIVE')
 
+    def test_campaign_leads_action_clamps_limit_and_offset(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Campaign leads pagination',
+            status='ACTIVE',
+        )
+        lead_one = Lead.objects.create(
+            organization=self.organization,
+            email='lead-one@acme.test',
+        )
+        lead_two = Lead.objects.create(
+            organization=self.organization,
+            email='lead-two@acme.test',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead_one,
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead_two,
+        )
+
+        response = self.client.get(
+            f'/api/v1/campaigns/{campaign.id}/leads/?limit=999999&offset=-5',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['limit'], 200)
+        self.assertEqual(response.data['offset'], 0)
+        self.assertEqual(response.data['total_leads'], 2)
+        self.assertEqual(len(response.data['leads']), 2)
+
+    def test_campaign_leads_action_rejects_non_numeric_limit(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Campaign leads bad pagination',
+            status='ACTIVE',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='lead-pagination@acme.test',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+        )
+
+        response = self.client.get(
+            f'/api/v1/campaigns/{campaign.id}/leads/?limit=abc',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['param'], 'limit')
+        self.assertIn('integer', response.data['error'])
+
     def test_condition_time_is_mapped_to_delay_minutes(self):
         payload = {
             'name': 'Condition delay mapping',

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -46,6 +46,27 @@ class CampaignViewSet(viewsets.ModelViewSet):
             .prefetch_related('steps', 'enrolled_leads')
         )
 
+    def _parse_leads_page_param(self, request, name, default, *, minimum, maximum=None):
+        raw_value = request.query_params.get(name)
+        if raw_value in (None, ''):
+            return default, None
+
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return None, Response(
+                {
+                    'error': f'`{name}` must be an integer.',
+                    'param': name,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        value = max(minimum, value)
+        if maximum is not None:
+            value = min(maximum, value)
+        return value, None
+
     def perform_create(self, serializer):
         serializer.save(organization=self.request.user.organization)
 
@@ -269,8 +290,17 @@ class CampaignViewSet(viewsets.ModelViewSet):
         """Get paginated list of enrolled leads with metrics."""
         campaign = self.get_object()
         status_filter = request.query_params.get('status')
-        limit = int(request.query_params.get('limit', 50))
-        offset = int(request.query_params.get('offset', 0))
+        limit, error_response = self._parse_leads_page_param(
+            request, 'limit', 50, minimum=1, maximum=200
+        )
+        if error_response:
+            return error_response
+
+        offset, error_response = self._parse_leads_page_param(
+            request, 'offset', 0, minimum=0
+        )
+        if error_response:
+            return error_response
 
         leads_qs = campaign.enrolled_leads.select_related('lead').order_by('-updated_at')
 


### PR DESCRIPTION
Closes #284\n\n- Parse limit/offset query params safely\n- Clamp limit to 1..200 and offset to a minimum of 0\n- Return 400 for non-integer pagination values\n- Add regression tests for clamping and invalid input\n\nValidation:\n- python3 -m py_compile backend/campaigns/views.py backend/campaigns/tests.py\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination validation for campaign leads endpoint: enforces maximum limit of 200 and minimum offset of 0, with consistent error responses for invalid parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->