### PR TITLE
fix csv import encoding fallback

### DIFF
--- a/backend/leads/migrations/0006_leadimportjob_source_encoding.py
+++ b/backend/leads/migrations/0006_leadimportjob_source_encoding.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('leads', '0005_merge_0004_leadimportjob_0004_tag_color'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='leadimportjob',
+            name='source_encoding',
+            field=models.CharField(blank=True, default='', max_length=64),
+        ),
+    ]

--- a/backend/leads/models.py
+++ b/backend/leads/models.py
@@ -43,6 +43,7 @@ class Lead(TenantModel):
 
 class LeadImportJob(TenantModel):
     filename = models.CharField(max_length=255)
+    source_encoding = models.CharField(max_length=64, blank=True, default='')
     total_rows = models.IntegerField(default=0)
     imported_count = models.IntegerField(default=0)
     failed_count = models.IntegerField(default=0)

--- a/backend/leads/serializers.py
+++ b/backend/leads/serializers.py
@@ -68,6 +68,7 @@ class LeadImportJobSerializer(serializers.ModelSerializer):
         fields = [
             'id',
             'filename',
+            'source_encoding',
             'total_rows',
             'imported_count',
             'failed_count',

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -4,6 +4,7 @@ from rest_framework.test import APITestCase
 
 from leads.models import BlockedDomain, Lead, Tag, LeadTag, LeadImportJob
 from leads.tasks import import_leads_from_csv
+from leads.views import _decode_csv_upload
 from tenants.models import Organization
 from users.models import User
 
@@ -65,6 +66,31 @@ class LeadImportTests(APITestCase):
                 'lead_source': 'Referral',
             },
         )
+
+    def test_decode_csv_upload_prefers_utf8_sig_then_detected_encoding_then_latin1(self):
+        utf8_bytes = '\ufeffemail\nutf8@example.com\n'.encode('utf-8')
+        decoded, encoding = _decode_csv_upload(utf8_bytes)
+        self.assertEqual(decoded, 'email\nutf8@example.com\n')
+        self.assertEqual(encoding, 'utf-8-sig')
+
+        cp1252_bytes = 'email\njosé@example.com\n'.encode('cp1252')
+        decoded, encoding = _decode_csv_upload(cp1252_bytes)
+        self.assertIn('josé@example.com', decoded)
+        self.assertIn(encoding.lower(), {'windows-1252', 'cp1252', 'iso-8859-1', 'latin-1'})
+
+    def test_import_records_source_encoding_on_job(self):
+        job = LeadImportJob.objects.create(
+            organization=self.organization,
+            filename='windows-export.csv',
+        )
+        csv_data = 'email,first_name\nmaría@example.com,María\n'.encode('cp1252').decode('cp1252')
+
+        import_leads_from_csv(csv_data, str(self.organization.id), str(job.id))
+
+        job.refresh_from_db()
+        self.assertTrue(job.source_encoding)
+        self.assertIn(job.source_encoding.lower(), {'windows-1252', 'cp1252', 'iso-8859-1', 'latin-1', 'utf-8-sig'})
+        self.assertTrue(Lead.objects.filter(organization=self.organization, email='maría@example.com').exists())
 
     def test_import_records_validation_errors_in_history_job(self):
         job = LeadImportJob.objects.create(

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -4,6 +4,12 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from users.permissions import IsOrgManager
+
+try:
+    import chardet
+except ImportError:  # pragma: no cover - optional dependency in older environments
+    chardet = None
+
 from .models import BlockedDomain, Lead, LeadImportJob, Tag, LeadTag
 from .serializers import BlockedDomainSerializer, LeadImportJobSerializer, LeadSerializer, TagSerializer
 
@@ -11,6 +17,29 @@ from .serializers import BlockedDomainSerializer, LeadImportJobSerializer, LeadS
 class LeadImportJobPagination(PageNumberPagination):
     page_size = 10
 
+
+def _decode_csv_upload(raw_bytes):
+    candidates = ['utf-8-sig']
+    detected_encoding = None
+
+    if chardet is not None:
+        detection = chardet.detect(raw_bytes)
+        detected_encoding = (detection or {}).get('encoding') or ''
+        confidence = (detection or {}).get('confidence') or 0
+        if detected_encoding and confidence >= 0.5:
+            candidates.append(detected_encoding)
+
+    candidates.append('latin-1')
+
+    last_error = None
+    for encoding in candidates:
+        try:
+            return raw_bytes.decode(encoding), encoding
+        except (UnicodeDecodeError, LookupError) as exc:
+            last_error = exc
+            continue
+
+    raise UnicodeDecodeError('csv', raw_bytes, 0, len(raw_bytes), f'Unable to decode CSV upload: {last_error}')
 
 class LeadViewSet(viewsets.ModelViewSet):
     serializer_class = LeadSerializer
@@ -97,13 +126,16 @@ class LeadViewSet(viewsets.ModelViewSet):
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
 
+        raw_bytes = file_obj.read()
+        file_contents, source_encoding = _decode_csv_upload(raw_bytes)
+
         job = LeadImportJob.objects.create(
             organization=request.user.organization,
             filename=file_obj.name or 'lead-import.csv',
+            source_encoding=source_encoding,
         )
         # Trigger async celery task
         from .tasks import import_leads_from_csv
-        file_contents = file_obj.read().decode('utf-8')
 
         # Ensure we pass the organization to the task
         import_leads_from_csv.delay(file_contents, request.user.organization.id, str(job.id))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ google-auth-oauthlib>=1.2,<2.0
 firebase-admin>=6.5,<7.0
 twilio>=9.0,<10.0
 gunicorn>=20.1,<21.0
+chardet>=5.2,<6.0


### PR DESCRIPTION
Closes #285\n\n- Decode uploads with utf-8-sig first, then chardet-detected encoding, then latin-1 fallback\n- Persist the detected source encoding on LeadImportJob\n- Add regression coverage for UTF-8 BOM, cp1252, and source_encoding logging\n- Add chardet to requirements\n\nValidation:\n- python3 -m py_compile backend/leads/views.py backend/leads/tests.py backend/leads/models.py backend/leads/serializers.py backend/leads/migrations/0006_leadimportjob_source_encoding.py\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CSV import functionality to automatically detect and handle different character encodings, providing better support for files containing accented characters and non-UTF-8 formats.
  * System now records the detected encoding for each file import for better tracking and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->