### PR TITLE
feat password reset flow

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -34,3 +34,19 @@ class RegisterSerializer(serializers.Serializer):
             role='ADMIN',  # First user in org is admin
         )
         return user
+
+
+class PasswordResetRequestSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    uid = serializers.CharField()
+    token = serializers.CharField()
+    new_password = serializers.CharField(write_only=True)
+    confirm_password = serializers.CharField(write_only=True)
+
+    def validate(self, attrs):
+        if attrs['new_password'] != attrs['confirm_password']:
+            raise serializers.ValidationError({'confirm_password': 'Passwords do not match.'})
+        return attrs

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,5 +1,10 @@
+from unittest.mock import patch
+
 from rest_framework import status
 from rest_framework.test import APITestCase
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 from tenants.models import Organization
 from users.models import User
@@ -104,3 +109,66 @@ class AuthMeViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue(Organization.objects.filter(id=self.organization.id).exists())
         self.assertTrue(User.objects.filter(id=self.user.id).exists())
+
+
+class PasswordResetFlowTests(APITestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name='Reset Org')
+        self.user = User.objects.create_user(
+            email='forgot@example.com',
+            password='StrongPass123!',
+            organization=self.organization,
+            role=User.ROLE_ADMIN,
+        )
+
+    @patch('users.views.send_mail')
+    def test_password_reset_request_sends_email_for_existing_user(self, mocked_send_mail):
+        response = self.client.post(
+            '/api/v1/auth/password-reset/',
+            {'email': 'forgot@example.com'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mocked_send_mail.assert_called_once()
+        sent_args, sent_kwargs = mocked_send_mail.call_args
+        self.assertIn('LeadOrbit password reset', sent_kwargs['subject'])
+        self.assertEqual(sent_kwargs['recipient_list'], ['forgot@example.com'])
+        self.assertIn('/password-reset.html?uid=', sent_kwargs['message'])
+
+    def test_password_reset_confirm_updates_password(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        token = default_token_generator.make_token(self.user)
+
+        response = self.client.post(
+            '/api/v1/auth/password-reset/confirm/',
+            {
+                'uid': uid,
+                'token': token,
+                'new_password': 'NewStrongPass123!',
+                'confirm_password': 'NewStrongPass123!',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password('NewStrongPass123!'))
+
+    def test_password_reset_confirm_rejects_mismatched_passwords(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        token = default_token_generator.make_token(self.user)
+
+        response = self.client.post(
+            '/api/v1/auth/password-reset/confirm/',
+            {
+                'uid': uid,
+                'token': token,
+                'new_password': 'NewStrongPass123!',
+                'confirm_password': 'DifferentPass123!',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('confirm_password', response.data)

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -136,6 +136,21 @@ class PasswordResetFlowTests(APITestCase):
         self.assertEqual(sent_kwargs['recipient_list'], ['forgot@example.com'])
         self.assertIn('/password-reset.html?uid=', sent_kwargs['message'])
 
+    @patch('users.views.send_mail')
+    def test_password_reset_request_is_generic_for_unknown_email(self, mocked_send_mail):
+        response = self.client.post(
+            '/api/v1/auth/password-reset/',
+            {'email': 'missing@example.com'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data.get('detail'),
+            'If the email exists, a reset link has been sent.',
+        )
+        mocked_send_mail.assert_not_called()
+
     def test_password_reset_confirm_updates_password(self):
         uid = urlsafe_base64_encode(force_bytes(self.user.pk))
         token = default_token_generator.make_token(self.user)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,7 +1,10 @@
+import logging
+
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.throttling import AnonRateThrottle
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.password_validation import validate_password
@@ -19,6 +22,8 @@ from .serializers import (
 )
 from rest_framework_simplejwt.tokens import RefreshToken
 
+logger = logging.getLogger(__name__)
+
 class AuthViewSet(viewsets.GenericViewSet):
     @action(detail=False, methods=['post'], permission_classes=[AllowAny])
     def register(self, request):
@@ -33,7 +38,13 @@ class AuthViewSet(viewsets.GenericViewSet):
             }, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    @action(detail=False, methods=['post'], permission_classes=[AllowAny], url_path='password-reset')
+    @action(
+        detail=False,
+        methods=['post'],
+        permission_classes=[AllowAny],
+        throttle_classes=[AnonRateThrottle],
+        url_path='password-reset',
+    )
     def password_reset(self, request):
         serializer = PasswordResetRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -41,28 +52,37 @@ class AuthViewSet(viewsets.GenericViewSet):
         email = serializer.validated_data['email'].strip()
         user = User.objects.filter(email__iexact=email).first()
         if user:
-            uid = urlsafe_base64_encode(force_bytes(user.pk))
-            token = default_token_generator.make_token(user)
-            frontend_base = getattr(settings, 'FRONTEND_BASE_URL', '').rstrip('/') or 'http://localhost:8080'
-            reset_link = f'{frontend_base}/password-reset.html?uid={uid}&token={token}'
-            send_mail(
-                subject='LeadOrbit password reset',
-                message=(
-                    'We received a request to reset your LeadOrbit password.\n\n'
-                    f'Reset it here: {reset_link}\n\n'
-                    'If you did not request this, you can ignore this email.'
-                ),
-                from_email=getattr(settings, 'DEFAULT_FROM_EMAIL', 'no-reply@leadorbit.local'),
-                recipient_list=[user.email],
-                fail_silently=False,
-            )
+            try:
+                uid = urlsafe_base64_encode(force_bytes(user.pk))
+                token = default_token_generator.make_token(user)
+                frontend_base = getattr(settings, 'FRONTEND_BASE_URL', '').rstrip('/') or 'http://localhost:8080'
+                reset_link = f'{frontend_base}/password-reset.html?uid={uid}&token={token}'
+                send_mail(
+                    subject='LeadOrbit password reset',
+                    message=(
+                        'We received a request to reset your LeadOrbit password.\n\n'
+                        f'Reset it here: {reset_link}\n\n'
+                        'If you did not request this, you can ignore this email.'
+                    ),
+                    from_email=getattr(settings, 'DEFAULT_FROM_EMAIL', 'no-reply@leadorbit.local'),
+                    recipient_list=[user.email],
+                    fail_silently=False,
+                )
+            except Exception:
+                logger.exception('Password reset email delivery failed for %s', user.email)
 
         return Response(
             {'detail': 'If the email exists, a reset link has been sent.'},
             status=status.HTTP_200_OK,
         )
 
-    @action(detail=False, methods=['post'], permission_classes=[AllowAny], url_path='password-reset/confirm')
+    @action(
+        detail=False,
+        methods=['post'],
+        permission_classes=[AllowAny],
+        throttle_classes=[AnonRateThrottle],
+        url_path='password-reset/confirm',
+    )
     def password_reset_confirm(self, request):
         serializer = PasswordResetConfirmSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -2,11 +2,21 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from django.conf import settings
+from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.mail import send_mail
+from django.utils.encoding import force_bytes, force_str
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from .models import User
 from .permissions import IsOrgAdmin
-from .serializers import UserSerializer, RegisterSerializer
+from .serializers import (
+    UserSerializer,
+    RegisterSerializer,
+    PasswordResetRequestSerializer,
+    PasswordResetConfirmSerializer,
+)
 from rest_framework_simplejwt.tokens import RefreshToken
 
 class AuthViewSet(viewsets.GenericViewSet):
@@ -22,6 +32,66 @@ class AuthViewSet(viewsets.GenericViewSet):
                 'access': str(refresh.access_token),
             }, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=['post'], permission_classes=[AllowAny], url_path='password-reset')
+    def password_reset(self, request):
+        serializer = PasswordResetRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        email = serializer.validated_data['email'].strip()
+        user = User.objects.filter(email__iexact=email).first()
+        if user:
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            token = default_token_generator.make_token(user)
+            frontend_base = getattr(settings, 'FRONTEND_BASE_URL', '').rstrip('/') or 'http://localhost:8080'
+            reset_link = f'{frontend_base}/password-reset.html?uid={uid}&token={token}'
+            send_mail(
+                subject='LeadOrbit password reset',
+                message=(
+                    'We received a request to reset your LeadOrbit password.\n\n'
+                    f'Reset it here: {reset_link}\n\n'
+                    'If you did not request this, you can ignore this email.'
+                ),
+                from_email=getattr(settings, 'DEFAULT_FROM_EMAIL', 'no-reply@leadorbit.local'),
+                recipient_list=[user.email],
+                fail_silently=False,
+            )
+
+        return Response(
+            {'detail': 'If the email exists, a reset link has been sent.'},
+            status=status.HTTP_200_OK,
+        )
+
+    @action(detail=False, methods=['post'], permission_classes=[AllowAny], url_path='password-reset/confirm')
+    def password_reset_confirm(self, request):
+        serializer = PasswordResetConfirmSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        uidb64 = serializer.validated_data['uid']
+        token = serializer.validated_data['token']
+        new_password = serializer.validated_data['new_password']
+
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            return Response({'token': ['Invalid or expired token.']}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not default_token_generator.check_token(user, token):
+            return Response({'token': ['Invalid or expired token.']}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            validate_password(new_password, user)
+        except DjangoValidationError as exc:
+            return Response({'new_password': list(exc.messages)}, status=status.HTTP_400_BAD_REQUEST)
+
+        user.set_password(new_password)
+        user.save(update_fields=['password'])
+
+        return Response(
+            {'detail': 'Password has been reset successfully.'},
+            status=status.HTTP_200_OK,
+        )
 
     @action(detail=False, methods=['get', 'patch'], permission_classes=[IsAuthenticated])
     def me(self, request):

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -141,6 +141,9 @@
                         <div class="text-center mt-4">
                             <p class="mb-0 small text-white-50">Don't have an account? <a href="/register.html"
                                     class="text-decoration-none fw-semibold" style="color: #00ffca;">Create one</a></p>
+                            <p class="mb-0 mt-2 small text-white-50">
+                                <a href="/password-reset.html" class="text-decoration-none fw-semibold" style="color: #00ffca;">Forgot password?</a>
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/frontend/password-reset.html
+++ b/frontend/password-reset.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>LeadOrbit - Reset Password</title>
+    <meta name="description" content="LeadOrbit password reset page.">
+    <meta name="author" content="LeadOrbit Team">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="./theme-boot.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Sora:wght@500;600;700;800&display=swap" rel="stylesheet">
+    <link href="./theme.css" rel="stylesheet">
+    <style>
+        body.auth-page {
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%) !important;
+            font-family: 'Manrope', sans-serif;
+            min-height: 100vh;
+        }
+
+        .custom-glass-card {
+            background: rgba(30, 41, 59, 0.72) !important;
+            backdrop-filter: blur(16px) !important;
+            -webkit-backdrop-filter: blur(16px) !important;
+            border: 1px solid rgba(255, 255, 255, 0.08) !important;
+            border-radius: 20px;
+        }
+
+        .brand-gradient {
+            background: linear-gradient(45deg, #00b4db, #00ffca) !important;
+            -webkit-background-clip: text !important;
+            background-clip: text !important;
+            -webkit-text-fill-color: transparent !important;
+            color: transparent !important;
+            display: inline-block;
+        }
+
+        .custom-input {
+            background-color: rgba(15, 23, 42, 0.5) !important;
+            border: 1px solid rgba(255, 255, 255, 0.1) !important;
+            color: #ffffff !important;
+        }
+
+        .custom-input:focus {
+            background-color: rgba(15, 23, 42, 0.8) !important;
+            border-color: #00b4db !important;
+            box-shadow: 0 0 0 0.25rem rgba(0, 180, 219, 0.25) !important;
+            color: #ffffff !important;
+        }
+    </style>
+</head>
+
+<body class="auth-page d-flex align-items-center min-vh-100">
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-md-6 col-lg-4">
+                <div class="custom-glass-card p-4 shadow-lg">
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <a href="/login.html" class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2">
+                                <span>&larr;</span>
+                                <span>Back to Login</span>
+                            </a>
+                        </div>
+
+                        <div class="text-center mb-4">
+                            <h2 class="brand-gradient mb-1" style="font-family: 'Sora', sans-serif; font-weight: 800; font-size: 2.3rem;">LeadOrbit</h2>
+                            <p class="text-white-50 small mb-0">Choose a new password for your account.</p>
+                        </div>
+
+                        <div id="reset-alert" class="alert alert-danger d-none" role="alert"></div>
+                        <div id="success-alert" class="alert alert-success d-none" role="alert"></div>
+
+                        <form aria-label="Password reset form">
+                            <div class="mb-3">
+                                <label for="newPassword" class="form-label text-white-50 small fw-semibold">New Password</label>
+                                <input type="password" class="form-control form-control-lg fs-6 custom-input" id="newPassword" required minlength="8" autocomplete="new-password" placeholder="Enter new password">
+                            </div>
+
+                            <div class="mb-4">
+                                <label for="confirmPassword" class="form-label text-white-50 small fw-semibold">Confirm Password</label>
+                                <input type="password" class="form-control form-control-lg fs-6 custom-input" id="confirmPassword" required minlength="8" autocomplete="new-password" placeholder="Confirm new password">
+                            </div>
+
+                            <div class="d-grid mb-3">
+                                <button class="btn btn-lg fw-semibold text-dark" style="background: linear-gradient(45deg, #00b4db, #00ffca); border: none;" type="submit">Reset Password</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const storedApiBase = localStorage.getItem('api_base_url');
+        const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+        const defaultApiBase = isLocalhost
+            ? 'http://127.0.0.1:8000/api/v1'
+            : 'https://leadorbit.onrender.com/api/v1';
+        const API_BASE = (storedApiBase || defaultApiBase).replace(/\/$/, '');
+
+        const alertEl = document.getElementById('reset-alert');
+        const successEl = document.getElementById('success-alert');
+        const form = document.querySelector('form');
+        const params = new URLSearchParams(window.location.search);
+        const uid = params.get('uid');
+        const token = params.get('token');
+
+        const showError = (message) => {
+            successEl.classList.add('d-none');
+            alertEl.textContent = message;
+            alertEl.classList.remove('d-none');
+        };
+
+        const showSuccess = (message) => {
+            alertEl.classList.add('d-none');
+            successEl.textContent = message;
+            successEl.classList.remove('d-none');
+        };
+
+        if (!uid || !token) {
+            showError('This reset link is missing the token or user id. Please request a new password reset email.');
+            form.querySelector('button[type="submit"]').disabled = true;
+        }
+
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+
+            const newPassword = document.getElementById('newPassword').value;
+            const confirmPassword = document.getElementById('confirmPassword').value;
+
+            if (newPassword !== confirmPassword) {
+                showError('Passwords do not match.');
+                return;
+            }
+
+            try {
+                const button = form.querySelector('button[type="submit"]');
+                button.disabled = true;
+                button.textContent = 'Resetting...';
+
+                const response = await fetch(`${API_BASE}/auth/password-reset/confirm/`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ uid, token, new_password: newPassword, confirm_password: confirmPassword }),
+                });
+
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    const message = data?.new_password?.[0] || data?.token?.[0] || data?.detail || 'Unable to reset password.';
+                    throw new Error(message);
+                }
+
+                showSuccess('Password reset successful. You can sign in with your new password now.');
+                button.textContent = 'Reset Password';
+                setTimeout(() => {
+                    window.location.href = '/login.html';
+                }, 1800);
+            } catch (error) {
+                showError(error.message || 'Unable to reset password.');
+                const button = form.querySelector('button[type="submit"]');
+                button.disabled = false;
+                button.textContent = 'Reset Password';
+            }
+        });
+    </script>
+</body>
+
+</html>

--- a/frontend/password-reset.html
+++ b/frontend/password-reset.html
@@ -7,6 +7,7 @@
     <meta name="author" content="LeadOrbit Team">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="referrer" content="no-referrer">
     <script src="./theme-boot.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
@@ -66,25 +67,27 @@
 
                         <div class="text-center mb-4">
                             <h2 class="brand-gradient mb-1" style="font-family: 'Sora', sans-serif; font-weight: 800; font-size: 2.3rem;">LeadOrbit</h2>
-                            <p class="text-white-50 small mb-0">Choose a new password for your account.</p>
+                            <p id="page-copy" class="text-white-50 small mb-0">Choose a new password for your account.</p>
                         </div>
 
                         <div id="reset-alert" class="alert alert-danger d-none" role="alert"></div>
                         <div id="success-alert" class="alert alert-success d-none" role="alert"></div>
 
                         <form aria-label="Password reset form">
-                            <div class="mb-3">
-                                <label for="newPassword" class="form-label text-white-50 small fw-semibold">New Password</label>
-                                <input type="password" class="form-control form-control-lg fs-6 custom-input" id="newPassword" required minlength="8" autocomplete="new-password" placeholder="Enter new password">
+                            <div id="email-field" class="mb-3 d-none">
+                                <label for="email" class="form-label text-white-50 small fw-semibold">Email Address</label>
+                                <input type="email" class="form-control form-control-lg fs-6 custom-input" id="email" autocomplete="email" placeholder="name@example.com">
                             </div>
 
-                            <div class="mb-4">
+                            <div id="password-field" class="mb-3 d-none">
+                                <label for="newPassword" class="form-label text-white-50 small fw-semibold">New Password</label>
+                                <input type="password" class="form-control form-control-lg fs-6 custom-input" id="newPassword" required minlength="8" autocomplete="new-password" placeholder="Enter new password">
                                 <label for="confirmPassword" class="form-label text-white-50 small fw-semibold">Confirm Password</label>
-                                <input type="password" class="form-control form-control-lg fs-6 custom-input" id="confirmPassword" required minlength="8" autocomplete="new-password" placeholder="Confirm new password">
+                                <input type="password" class="form-control form-control-lg fs-6 custom-input mt-2" id="confirmPassword" required minlength="8" autocomplete="new-password" placeholder="Confirm new password">
                             </div>
 
                             <div class="d-grid mb-3">
-                                <button class="btn btn-lg fw-semibold text-dark" style="background: linear-gradient(45deg, #00b4db, #00ffca); border: none;" type="submit">Reset Password</button>
+                                <button id="submit-btn" class="btn btn-lg fw-semibold text-dark" style="background: linear-gradient(45deg, #00b4db, #00ffca); border: none;" type="submit">Reset Password</button>
                             </div>
                         </form>
                     </div>
@@ -104,9 +107,23 @@
         const alertEl = document.getElementById('reset-alert');
         const successEl = document.getElementById('success-alert');
         const form = document.querySelector('form');
+        const submitBtn = document.getElementById('submit-btn');
+        const pageCopy = document.getElementById('page-copy');
+        const emailField = document.getElementById('email-field');
+        const passwordField = document.getElementById('password-field');
         const params = new URLSearchParams(window.location.search);
-        const uid = params.get('uid');
-        const token = params.get('token');
+        const isConfirmMode = Boolean(params.get('uid') && params.get('token'));
+        const uid = params.get('uid') || sessionStorage.getItem('password_reset_uid') || '';
+        const token = params.get('token') || sessionStorage.getItem('password_reset_token') || '';
+        const emailInput = document.getElementById('email');
+        const newPasswordInput = document.getElementById('newPassword');
+        const confirmPasswordInput = document.getElementById('confirmPassword');
+
+        if (params.get('uid') && params.get('token')) {
+            sessionStorage.setItem('password_reset_uid', params.get('uid'));
+            sessionStorage.setItem('password_reset_token', params.get('token'));
+            window.history.replaceState({}, document.title, '/password-reset.html');
+        }
 
         const showError = (message) => {
             successEl.classList.add('d-none');
@@ -120,49 +137,96 @@
             successEl.classList.remove('d-none');
         };
 
-        if (!uid || !token) {
-            showError('This reset link is missing the token or user id. Please request a new password reset email.');
-            form.querySelector('button[type="submit"]').disabled = true;
+        if (isConfirmMode) {
+            pageCopy.textContent = 'Choose a new password for your account.';
+            passwordField.classList.remove('d-none');
+            submitBtn.textContent = 'Reset Password';
+            newPasswordInput.required = true;
+            confirmPasswordInput.required = true;
+            emailInput.required = false;
+            emailInput.disabled = true;
+        } else {
+            pageCopy.textContent = 'Request a password reset email.';
+            emailField.classList.remove('d-none');
+            submitBtn.textContent = 'Send Reset Link';
+            emailInput.required = true;
+            emailInput.disabled = false;
+            newPasswordInput.required = false;
+            confirmPasswordInput.required = false;
+            newPasswordInput.disabled = true;
+            confirmPasswordInput.disabled = true;
         }
 
         form.addEventListener('submit', async (event) => {
             event.preventDefault();
 
-            const newPassword = document.getElementById('newPassword').value;
-            const confirmPassword = document.getElementById('confirmPassword').value;
+            if (isConfirmMode) {
+                const newPassword = document.getElementById('newPassword').value;
+                const confirmPassword = document.getElementById('confirmPassword').value;
 
-            if (newPassword !== confirmPassword) {
-                showError('Passwords do not match.');
+                if (newPassword !== confirmPassword) {
+                    showError('Passwords do not match.');
+                    return;
+                }
+
+                try {
+                    submitBtn.disabled = true;
+                    submitBtn.textContent = 'Resetting...';
+
+                    const response = await fetch(`${API_BASE}/auth/password-reset/confirm/`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ uid, token, new_password: newPassword, confirm_password: confirmPassword }),
+                    });
+
+                    const data = await response.json().catch(() => ({}));
+                    if (!response.ok) {
+                        const message = data?.new_password?.[0] || data?.token?.[0] || data?.detail || 'Unable to reset password.';
+                        throw new Error(message);
+                    }
+
+                    showSuccess('Password reset successful. You can sign in with your new password now.');
+                    submitBtn.textContent = 'Reset Password';
+                    setTimeout(() => {
+                        window.location.href = '/login.html';
+                    }, 1800);
+                } catch (error) {
+                    showError(error.message || 'Unable to reset password.');
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = 'Reset Password';
+                }
                 return;
             }
 
             try {
-                const button = form.querySelector('button[type="submit"]');
-                button.disabled = true;
-                button.textContent = 'Resetting...';
+                const email = document.getElementById('email').value.trim();
+                if (!email) {
+                    showError('Please enter your email address.');
+                    return;
+                }
 
-                const response = await fetch(`${API_BASE}/auth/password-reset/confirm/`, {
+                submitBtn.disabled = true;
+                submitBtn.textContent = 'Sending...';
+
+                const response = await fetch(`${API_BASE}/auth/password-reset/`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ uid, token, new_password: newPassword, confirm_password: confirmPassword }),
+                    body: JSON.stringify({ email }),
                 });
 
                 const data = await response.json().catch(() => ({}));
                 if (!response.ok) {
-                    const message = data?.new_password?.[0] || data?.token?.[0] || data?.detail || 'Unable to reset password.';
-                    throw new Error(message);
+                    throw new Error(data?.detail || 'Unable to request password reset.');
                 }
 
-                showSuccess('Password reset successful. You can sign in with your new password now.');
-                button.textContent = 'Reset Password';
-                setTimeout(() => {
-                    window.location.href = '/login.html';
-                }, 1800);
+                showSuccess(data?.detail || 'If the email exists, a reset link has been sent.');
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Send Reset Link';
+                form.reset();
             } catch (error) {
-                showError(error.message || 'Unable to reset password.');
-                const button = form.querySelector('button[type="submit"]');
-                button.disabled = false;
-                button.textContent = 'Reset Password';
+                showError(error.message || 'Unable to request password reset.');
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Send Reset Link';
             }
         });
     </script>

--- a/frontend/password-reset.html
+++ b/frontend/password-reset.html
@@ -5,9 +5,9 @@
     <title>LeadOrbit - Reset Password</title>
     <meta name="description" content="LeadOrbit password reset page.">
     <meta name="author" content="LeadOrbit Team">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="referrer" content="no-referrer">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="referrer" content="no-referrer">
     <script src="./theme-boot.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
@@ -112,9 +112,13 @@
         const emailField = document.getElementById('email-field');
         const passwordField = document.getElementById('password-field');
         const params = new URLSearchParams(window.location.search);
-        const isConfirmMode = Boolean(params.get('uid') && params.get('token'));
-        const uid = params.get('uid') || sessionStorage.getItem('password_reset_uid') || '';
-        const token = params.get('token') || sessionStorage.getItem('password_reset_token') || '';
+        const storedUid = sessionStorage.getItem('password_reset_uid') || '';
+        const storedToken = sessionStorage.getItem('password_reset_token') || '';
+        const isConfirmMode = Boolean(
+            (params.get('uid') && params.get('token')) || (storedUid && storedToken),
+        );
+        const uid = params.get('uid') || storedUid;
+        const token = params.get('token') || storedToken;
         const emailInput = document.getElementById('email');
         const newPasswordInput = document.getElementById('newPassword');
         const confirmPasswordInput = document.getElementById('confirmPassword');
@@ -181,11 +185,13 @@
 
                     const data = await response.json().catch(() => ({}));
                     if (!response.ok) {
-                        const message = data?.new_password?.[0] || data?.token?.[0] || data?.detail || 'Unable to reset password.';
+                        const message = data?.new_password?.[0] || data?.confirm_password?.[0] || data?.token?.[0] || data?.email?.[0] || data?.detail || 'Unable to reset password.';
                         throw new Error(message);
                     }
 
                     showSuccess('Password reset successful. You can sign in with your new password now.');
+                    sessionStorage.removeItem('password_reset_uid');
+                    sessionStorage.removeItem('password_reset_token');
                     submitBtn.textContent = 'Reset Password';
                     setTimeout(() => {
                         window.location.href = '/login.html';
@@ -216,7 +222,7 @@
 
                 const data = await response.json().catch(() => ({}));
                 if (!response.ok) {
-                    throw new Error(data?.detail || 'Unable to request password reset.');
+                    throw new Error(data?.email?.[0] || data?.detail || 'Unable to request password reset.');
                 }
 
                 showSuccess(data?.detail || 'If the email exists, a reset link has been sent.');


### PR DESCRIPTION
## What changed
- Added `POST /api/v1/auth/password-reset/` to email a signed reset link for known users.
- Added `POST /api/v1/auth/password-reset/confirm/` to validate the token and set a new password.
- Added a password reset page and linked it from the login screen.
- Added tests for request, success, and validation failure paths.

## Why
- The app had no built-in way for users to recover access without admin intervention.

## Validation
- `python3 -m py_compile /tmp/leadorbit-336/backend/users/views.py /tmp/leadorbit-336/backend/users/serializers.py /tmp/leadorbit-336/backend/users/tests.py`
- `git -C /tmp/leadorbit-336 diff --check`

Closes #334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unauthenticated password reset request and confirmation endpoints, with email-based reset links and password update after successful confirmation.
  * Added a **“Forgot password?”** link to the login page to guide users into the reset flow.
  * Introduced a complete **password reset** page that supports both request and confirm modes, validates matching new passwords on the client, and displays server-side errors and success confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->