### PR TITLE
fix login inline error messages

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -133,7 +133,16 @@ export const login = async (email, password) => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })
     });
-    if (!res.ok) throw new Error("Login failed");
+    if (!res.ok) {
+        let message = 'Login failed. Please check your credentials.';
+        try {
+            const data = await res.json();
+            message = data.detail || data.non_field_errors?.[0] || data.email?.[0] || message;
+        } catch {
+            // Keep the generic fallback when the backend does not return JSON.
+        }
+        throw new Error(message);
+    }
     const data = await res.json();
     setTokens(data.access, data.refresh);
     return data;

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -96,6 +96,10 @@
                         </div>
 
                         <form aria-label="Login form">
+                            <div id="login-error" class="alert alert-danger alert-dismissible fade d-none" role="alert">
+                                <span id="login-error-message"></span>
+                                <button type="button" class="btn-close" aria-label="Dismiss" id="login-error-close"></button>
+                            </div>
                             <div class="mb-3">
                                 <label for="floatingInput" class="form-label text-white-50 small fw-semibold">Email Address</label>
                                 <div class="input-group">
@@ -155,22 +159,52 @@
 
         document.addEventListener('DOMContentLoaded', () => {
             const form = document.querySelector('form');
+            const errorBox = document.getElementById('login-error');
+            const errorMessage = document.getElementById('login-error-message');
+            const dismissButton = document.getElementById('login-error-close');
+            const submitButton = form?.querySelector('button[type="submit"]');
+
+            const clearError = () => {
+                if (!errorBox || !errorMessage) {
+                    return;
+                }
+                errorMessage.textContent = '';
+                errorBox.classList.add('d-none');
+                errorBox.classList.remove('show');
+            };
+
+            const showError = (message) => {
+                if (!errorBox || !errorMessage) {
+                    alert(message);
+                    return;
+                }
+                errorMessage.textContent = message;
+                errorBox.classList.remove('d-none');
+                errorBox.classList.add('show');
+            };
+
+            dismissButton?.addEventListener('click', clearError);
+
             if (form) {
                 form.addEventListener('submit', async (e) => {
                     e.preventDefault();
+                    clearError();
                     const email = document.getElementById('floatingInput').value;
                     const password = document.getElementById('floatingPassword').value;
                     try {
-                        const btn = form.querySelector('button[type="submit"]');
-                        btn.disabled = true;
-                        btn.textContent = 'Signing In...';
+                        if (submitButton) {
+                            submitButton.disabled = true;
+                            submitButton.textContent = 'Signing In...';
+                        }
                         await login(email, password);
                         window.location.href = '/dashboard.html';
                     } catch (err) {
-                        alert('Login failed. Please check your credentials.');
-                        const btn = form.querySelector('button[type="submit"]');
-                        btn.disabled = false;
-                        btn.textContent = 'Sign In';
+                        showError(err?.message || 'Login failed. Please check your credentials.');
+                    } finally {
+                        if (submitButton) {
+                            submitButton.disabled = false;
+                            submitButton.textContent = 'Sign In';
+                        }
                     }
                 });
             }


### PR DESCRIPTION
## What changed
- Replaced the login page `alert()` with an inline Bootstrap error banner.
- Surface backend error details from the token endpoint when available.
- Clear the message on retry and let the dismiss button hide it manually.

## Why
- Login failures were too generic and forced a disruptive popup instead of keeping feedback near the form.

## Validation
- `rg -n "login-error|alert\(|Login failed|Signing In" frontend/login.html frontend/api.js`
- `git diff --check`

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced login error messages to provide specific validation feedback from the server rather than generic failure notifications.

* **New Features**
  * Inline dismissible error alerts on the login form improve error visibility and user experience.
  * Login button displays clearer visual status feedback while submissions are in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->