### PR TITLE
feat email verification flow

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -132,7 +132,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'users.authentication.EmailVerifiedJWTAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',

--- a/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0009_campaign_cached_counters'),
+        ('campaigns', '0009_campaignlead_bounce_metadata'),
+    ]
+
+    operations = []

--- a/backend/users/authentication.py
+++ b/backend/users/authentication.py
@@ -1,0 +1,10 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class EmailVerifiedJWTAuthentication(JWTAuthentication):
+    def get_user(self, validated_token):
+        user = super().get_user(validated_token)
+        if not getattr(user, 'is_email_verified', False):
+            raise AuthenticationFailed('Please verify your email before accessing the API.')
+        return user

--- a/backend/users/jwt.py
+++ b/backend/users/jwt.py
@@ -1,4 +1,11 @@
+from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 class CustomTokenObtainSerializer(TokenObtainPairSerializer):
     username_field = 'email'
+
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        if not getattr(self.user, 'is_email_verified', False):
+            raise serializers.ValidationError({'detail': 'Please verify your email before logging in.'})
+        return data

--- a/backend/users/migrations/0002_user_is_email_verified.py
+++ b/backend/users/migrations/0002_user_is_email_verified.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='is_email_verified',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/users/migrations/0003_merge_0002_user_is_email_verified_0002_user_member_role_default.py
+++ b/backend/users/migrations/0003_merge_0002_user_is_email_verified_0002_user_member_role_default.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_user_is_email_verified'),
+        ('users', '0002_user_member_role_default'),
+    ]
+
+    operations = []

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -31,6 +31,7 @@ class User(AbstractBaseUser, PermissionsMixin, TenantModel):
     )
     email = models.EmailField(unique=True)
     role = models.CharField(max_length=20, choices=ROLE_CHOICES, default=ROLE_MEMBER)
+    is_email_verified = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)
     is_staff = models.BooleanField(default=False)
 

--- a/backend/users/permissions.py
+++ b/backend/users/permissions.py
@@ -29,3 +29,11 @@ class IsOrgAdmin(RolePermission):
 class IsOrgManager(RolePermission):
     allowed_roles = frozenset({User.ROLE_ADMIN, User.ROLE_MANAGER})
     message = 'Only organization admins or managers can perform this action.'
+
+
+class IsEmailVerified(BasePermission):
+    message = 'Please verify your email before accessing the API.'
+
+    def has_permission(self, request, view):
+        user = getattr(request, 'user', None)
+        return bool(user and user.is_authenticated and getattr(user, 'is_email_verified', False))

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -11,7 +11,7 @@ class UserSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer(read_only=True)
     class Meta:
         model = User
-        fields = ['id', 'email', 'role', 'organization', 'is_active']
+        fields = ['id', 'email', 'role', 'organization', 'is_active', 'is_email_verified']
 
 class RegisterSerializer(serializers.Serializer):
     email = serializers.EmailField()
@@ -32,5 +32,6 @@ class RegisterSerializer(serializers.Serializer):
             password=validated_data['password'],
             organization=org,
             role='ADMIN',  # First user in org is admin
+            is_email_verified=False,
         )
         return user

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,8 +1,12 @@
+from unittest.mock import patch
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from tenants.models import Organization
+from users.jwt import CustomTokenObtainSerializer
 from users.models import User
+from users.views import generate_email_verification_token
 
 
 class RegisterViewTests(APITestCase):
@@ -27,6 +31,82 @@ class RegisterViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('email', response.data)
+
+    @patch('users.views.send_mail')
+    def test_register_sends_verification_email_without_tokens(self, mock_send_mail):
+        response = self.client.post(
+            '/api/v1/auth/register/',
+            {
+                'email': 'new@example.com',
+                'password': 'StrongPass123!',
+                'organization_name': 'New Org',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('message', response.data)
+        self.assertNotIn('access', response.data)
+        self.assertNotIn('refresh', response.data)
+        user = User.objects.get(email='new@example.com')
+        self.assertFalse(user.is_email_verified)
+        mock_send_mail.assert_called_once()
+        self.assertIn('email-verification.html?token=', mock_send_mail.call_args.args[1])
+
+    def test_verify_email_endpoint_marks_user_verified(self):
+        organization = Organization.objects.create(name='Verify Org')
+        user = User.objects.create_user(
+            email='verify@example.com',
+            password='StrongPass123!',
+            organization=organization,
+            role=User.ROLE_ADMIN,
+        )
+        token = generate_email_verification_token(user)
+
+        response = self.client.get(f'/api/v1/auth/verify-email/{token}/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user.refresh_from_db()
+        self.assertTrue(user.is_email_verified)
+        self.assertEqual(response.data['detail'], 'Email verified successfully.')
+
+    def test_token_obtain_rejects_unverified_user(self):
+        organization = Organization.objects.create(name='Login Org')
+        User.objects.create_user(
+            email='login@example.com',
+            password='StrongPass123!',
+            organization=organization,
+            role=User.ROLE_ADMIN,
+        )
+
+        response = self.client.post(
+            '/api/v1/token/',
+            {'email': 'login@example.com', 'password': 'StrongPass123!'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('detail', response.data)
+
+    def test_token_obtain_allows_verified_user(self):
+        organization = Organization.objects.create(name='Verified Login Org')
+        user = User.objects.create_user(
+            email='verified@example.com',
+            password='StrongPass123!',
+            organization=organization,
+            role=User.ROLE_ADMIN,
+            is_email_verified=True,
+        )
+
+        response = self.client.post(
+            '/api/v1/token/',
+            {'email': user.email, 'password': 'StrongPass123!'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
 
 
 class AuthMeViewTests(APITestCase):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,3 +1,9 @@
+import logging
+
+from django.conf import settings
+from django.core import signing
+from django.core.mail import send_mail
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -7,7 +13,36 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from .models import User
 from .permissions import IsOrgAdmin
 from .serializers import UserSerializer, RegisterSerializer
-from rest_framework_simplejwt.tokens import RefreshToken
+
+logger = logging.getLogger(__name__)
+
+EMAIL_VERIFICATION_SALT = 'users.email-verification'
+
+
+def generate_email_verification_token(user):
+    return signing.dumps(str(user.pk), salt=EMAIL_VERIFICATION_SALT)
+
+
+def build_email_verification_url(token):
+    frontend_base = (getattr(settings, 'FRONTEND_BASE_URL', '') or settings.BACKEND_BASE_URL).rstrip('/')
+    return f'{frontend_base}/email-verification.html?token={token}'
+
+
+def send_verification_email(user):
+    token = generate_email_verification_token(user)
+    verification_url = build_email_verification_url(token)
+    subject = 'Verify your LeadOrbit email'
+    message = (
+        f'Hi {user.email},\n\n'
+        'Please verify your email address to finish setting up your LeadOrbit account.\n'
+        f'Open this link to verify your account: {verification_url}\n\n'
+        'If you did not create this account, you can ignore this email.'
+    )
+    try:
+        send_mail(subject, message, getattr(settings, 'DEFAULT_FROM_EMAIL', 'noreply@leadorbit.local'), [user.email], fail_silently=False)
+    except Exception:
+        logger.exception('Failed to send verification email for user %s', user.email)
+    return verification_url
 
 class AuthViewSet(viewsets.GenericViewSet):
     @action(detail=False, methods=['post'], permission_classes=[AllowAny])
@@ -15,13 +50,30 @@ class AuthViewSet(viewsets.GenericViewSet):
         serializer = RegisterSerializer(data=request.data)
         if serializer.is_valid():
             user = serializer.save()
-            refresh = RefreshToken.for_user(user)
+            verification_url = send_verification_email(user)
             return Response({
                 'user': UserSerializer(user).data,
-                'refresh': str(refresh),
-                'access': str(refresh.access_token),
+                'message': 'Verification email sent. Please check your inbox to activate your account.',
+                'verification_url': verification_url,
             }, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=['get'], permission_classes=[AllowAny], url_path=r'verify-email/(?P<token>[^/]+)')
+    def verify_email(self, request, token=None):
+        try:
+            user_id = signing.loads(token, salt=EMAIL_VERIFICATION_SALT, max_age=60 * 60 * 24 * 7)
+        except signing.BadSignature:
+            return Response({'detail': 'Verification link is invalid or has expired.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        user = get_object_or_404(User, pk=user_id)
+        if not user.is_email_verified:
+            user.is_email_verified = True
+            user.save(update_fields=['is_email_verified'])
+
+        return Response({
+            'detail': 'Email verified successfully.',
+            'user': UserSerializer(user).data,
+        })
 
     @action(detail=False, methods=['get', 'patch'], permission_classes=[IsAuthenticated])
     def me(self, request):

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -146,7 +146,17 @@ export const register = async (userData) => {
         body: JSON.stringify(userData)
     });
     if (!res.ok) throw new Error("Registration failed");
-    const data = await res.json();
-    setTokens(data.access, data.refresh);
+    return await res.json();
+};
+
+export const verifyEmail = async (token) => {
+    const res = await fetch(`${API_BASE}/auth/verify-email/${encodeURIComponent(token)}/`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        throw new Error(data.detail || 'Email verification failed.');
+    }
     return data;
 };

--- a/frontend/email-verification.html
+++ b/frontend/email-verification.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LeadOrbit - Verify Email</title>
+    <meta name="description" content="Verify your LeadOrbit email address.">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <script src="./theme-boot.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="./theme.css" rel="stylesheet">
+    <style>
+        body {
+            min-height: 100vh;
+            background: var(--bg);
+            color: var(--ink-900);
+        }
+    </style>
+</head>
+
+<body class="d-flex align-items-center">
+    <div class="container py-5" style="max-width: 720px;">
+        <div class="card shadow-sm" style="border: 1px solid var(--line); border-radius: 16px;">
+            <div class="card-body p-4 p-md-5">
+                <div class="d-flex align-items-center gap-3 mb-4">
+                    <div class="rounded-circle d-inline-flex align-items-center justify-content-center" style="width:48px;height:48px;background:var(--primary);color:#fff;">
+                        <i class="bi bi-envelope-check fs-4" aria-hidden="true"></i>
+                    </div>
+                    <div>
+                        <h1 class="h4 mb-1">Verify your email</h1>
+                        <p class="mb-0 text-secondary" id="subtitle">We’re checking your link now.</p>
+                    </div>
+                </div>
+
+                <div id="status" class="alert alert-info" role="alert">
+                    If you just signed up, check your inbox for the verification link.
+                </div>
+
+                <div id="action-row" class="d-flex flex-wrap gap-2 d-none">
+                    <a class="btn btn-primary" href="/login.html">Go to login</a>
+                    <a class="btn btn-outline-secondary" href="/register.html">Create another account</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { verifyEmail } from './api.js';
+
+        const params = new URLSearchParams(window.location.search);
+        const token = params.get('token');
+        const email = params.get('email');
+        const status = document.getElementById('status');
+        const subtitle = document.getElementById('subtitle');
+        const actionRow = document.getElementById('action-row');
+
+        if (email && subtitle) {
+            subtitle.textContent = `A verification email was sent to ${email}.`;
+        }
+
+        const showActionLinks = () => {
+            actionRow?.classList.remove('d-none');
+        };
+
+        if (!token) {
+            status.className = 'alert alert-warning';
+            status.textContent = 'Check your inbox and open the verification link to activate your account.';
+            showActionLinks();
+        } else {
+            status.className = 'alert alert-info';
+            status.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Verifying your account...';
+            try {
+                const result = await verifyEmail(token);
+                status.className = 'alert alert-success';
+                status.textContent = result.detail || 'Your email has been verified successfully.';
+                showActionLinks();
+            } catch (err) {
+                status.className = 'alert alert-danger';
+                status.textContent = err?.message || 'Verification failed. The link may have expired.';
+                showActionLinks();
+            }
+        }
+    </script>
+</body>
+
+</html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -192,9 +192,9 @@
                             first_name, last_name, email, password, organization_name
                         });
 
-                        window.location.href = '/dashboard.html';
+                        window.location.href = `/email-verification.html?email=${encodeURIComponent(email)}`;
                     } catch (err) {
-                        alert('Registration failed. Please try again.');
+                        alert(err?.message || 'Registration failed. Please try again.');
                         const btn = form.querySelector('button[type="submit"]');
                         btn.disabled = false;
                         btn.textContent = 'Sign Up';


### PR DESCRIPTION
## What changed
- Added `is_email_verified` to the user model and blocked JWT auth until the email is verified.
- Added a signed email verification link that is sent on registration.
- Added a `/auth/verify-email/<token>/` endpoint and a frontend verification page.
- Updated registration to send users to the verification page instead of logging them in immediately.
- Added tests for registration, verification, and token gating.

## Why
- New accounts should not access the API until the email address is confirmed.

## Validation
- `python3 backend/manage.py test users -v 2`
- `python3 -m py_compile backend/users/models.py backend/users/views.py backend/users/serializers.py backend/users/jwt.py backend/users/authentication.py backend/users/permissions.py backend/users/tests.py backend/backend/settings.py`
- `git diff --check`

Closes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email verification is now required before accessing the API
  * Registration sends a verification email; users must verify via link before gaining full access
  * Added email verification page for managing verification workflow

* **Tests**
  * Added coverage for email verification authentication flow

* **Chores**
  * Database migrations to support email verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->