### PR TITLE
feat campaign daily send limits

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -132,7 +132,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'users.authentication.EmailVerifiedJWTAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',

--- a/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0009_campaign_cached_counters'),
+        ('campaigns', '0009_campaignlead_bounce_metadata'),
+    ]
+
+    operations = []

--- a/backend/campaigns/migrations/0011_daily_send_count.py
+++ b/backend/campaigns/migrations/0011_daily_send_count.py
@@ -1,0 +1,34 @@
+import uuid
+
+from django.db import migrations, models
+import django.utils.timezone
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DailySendCount',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('send_date', models.DateField(default=django.utils.timezone.now)),
+                ('count', models.PositiveIntegerField(default=0)),
+                ('connected_account', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='daily_send_counts', to='campaigns.connectedemailaccount')),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tenants.organization')),
+            ],
+            options={
+                'unique_together': {('organization', 'connected_account', 'send_date')},
+            },
+        ),
+        migrations.AddIndex(
+            model_name='dailysendcount',
+            index=models.Index(fields=['connected_account', 'send_date'], name='campaigns_dai_connected_a7b4f6_idx'),
+        ),
+    ]

--- a/backend/campaigns/models.py
+++ b/backend/campaigns/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.conf import settings
+from django.utils import timezone
 from tenants.models import TenantModel
 from leads.models import Lead
 import uuid
@@ -49,6 +50,25 @@ class Campaign(TenantModel):
 
     def __str__(self):
         return self.name
+
+
+class DailySendCount(TenantModel):
+    connected_account = models.ForeignKey(
+        ConnectedEmailAccount,
+        on_delete=models.CASCADE,
+        related_name='daily_send_counts',
+    )
+    send_date = models.DateField(default=timezone.now)
+    count = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        unique_together = ('organization', 'connected_account', 'send_date')
+        indexes = [
+            models.Index(fields=['connected_account', 'send_date']),
+        ]
+
+    def __str__(self):
+        return f"{self.connected_account.email_address} @ {self.send_date}: {self.count}"
 
 class SequenceStep(TenantModel):
     CHANNEL_CHOICES = (

--- a/backend/campaigns/serializers.py
+++ b/backend/campaigns/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 from django.db.models import Q
+from django.utils import timezone
 
-from .models import Campaign, CampaignLead, ConnectedEmailAccount, SequenceStep, EmailTemplate
+from .models import Campaign, CampaignLead, ConnectedEmailAccount, DailySendCount, SequenceStep, EmailTemplate
 
 DELAY_UNIT_TO_MINUTES = {
     'minutes': 1,
@@ -29,6 +30,8 @@ class CampaignSerializer(serializers.ModelSerializer):
     enrolled_lead_ids = serializers.SerializerMethodField()
     connected_account = serializers.SerializerMethodField()
     connected_account_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    daily_limit = serializers.SerializerMethodField()
+    sends_today = serializers.SerializerMethodField()
 
     class Meta:
         model = Campaign
@@ -45,6 +48,8 @@ class CampaignSerializer(serializers.ModelSerializer):
             'reply_count',
             'clicked_count',
             'bounced_count',
+            'daily_limit',
+            'sends_today',
             'created_at',
             'connected_account',
             'connected_account_id',
@@ -64,6 +69,27 @@ class CampaignSerializer(serializers.ModelSerializer):
             'email': obj.connected_account.email_address,
             'provider': obj.connected_account.provider,
         }
+
+    def get_daily_limit(self, obj):
+        settings = obj.settings if isinstance(obj.settings, dict) else {}
+        raw_limit = settings.get('daily_limit')
+        try:
+            if raw_limit in (None, ''):
+                return None
+            limit = int(raw_limit)
+            return limit if limit > 0 else None
+        except (TypeError, ValueError):
+            return None
+
+    def get_sends_today(self, obj):
+        if not obj.connected_account_id:
+            return 0
+        send_count = DailySendCount.objects.filter(
+            organization=obj.organization,
+            connected_account=obj.connected_account,
+            send_date=timezone.now().date(),
+        ).only('count').first()
+        return send_count.count if send_count else 0
 
     def validate_connected_account_id(self, value):
         if value is None:

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -1,21 +1,89 @@
-import logging from datetime 
-import timedelta from celery 
-import shared_task from django.conf 
-import settings as django_settings from django.utils 
-import timezone from .ai 
-import _apply_merge_tags, personalize_email from .gmail_service
-import build_unsubscribe_url, check_for_replies, send_gmail from .sms_service 
-import send_sms, initiate_call from .models 
-import CampaignLead, SequenceStep from leads.models 
-import BlockedDomain, normalize_domain
-
-
+import logging
 import urllib.parse
+from datetime import datetime, timedelta
+
 from bs4 import BeautifulSoup
 from django.core.signing import Signer
+from django.db import transaction
+from django.conf import settings as django_settings
+from django.utils import timezone
+from celery import shared_task
+
+from .ai import _apply_merge_tags, personalize_email
+from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
+from .sms_service import send_sms, initiate_call
+from .models import CampaignLead, SequenceStep, DailySendCount
+from leads.models import BlockedDomain, normalize_domain
 
 
 logger = logging.getLogger(__name__)
+
+
+def _get_daily_send_limit(campaign):
+    settings = campaign.settings if isinstance(campaign.settings, dict) else {}
+    raw_limit = settings.get('daily_limit')
+    try:
+        if raw_limit in (None, ''):
+            return None
+        limit = int(raw_limit)
+        return limit if limit > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _get_today_send_count(organization, connected_account, send_date):
+    if not connected_account:
+        return 0
+    record = DailySendCount.objects.filter(
+        organization=organization,
+        connected_account=connected_account,
+        send_date=send_date,
+    ).only('count').first()
+    return record.count if record else 0
+
+
+def _reserve_daily_send_slot(campaign, connected_account, now=None):
+    now = now or timezone.now()
+    limit = _get_daily_send_limit(campaign)
+    if not limit or not connected_account:
+        return True, None
+
+    send_date = now.date()
+    with transaction.atomic():
+        counter, _ = DailySendCount.objects.select_for_update().get_or_create(
+            organization=campaign.organization,
+            connected_account=connected_account,
+            send_date=send_date,
+            defaults={'count': 0},
+        )
+        if counter.count >= limit:
+            return False, counter.count
+
+        counter.count += 1
+        counter.save(update_fields=['count'])
+        return True, counter.count
+
+
+def _release_daily_send_slot(campaign, connected_account, now=None):
+    now = now or timezone.now()
+    if not connected_account:
+        return
+
+    send_date = now.date()
+    with transaction.atomic():
+        counter = DailySendCount.objects.select_for_update().filter(
+            organization=campaign.organization,
+            connected_account=connected_account,
+            send_date=send_date,
+        ).first()
+        if counter and counter.count > 0:
+            counter.count -= 1
+            counter.save(update_fields=['count'])
+
+
+def _start_of_next_day(now=None):
+    now = now or timezone.now()
+    return timezone.make_aware(datetime.combine((now + timedelta(days=1)).date(), datetime.min.time()))
 
 def _get_campaign_steps(campaign):
     """
@@ -481,6 +549,16 @@ def send_email_step(campaign_lead_id, step_id):
         if _skip_blocked_domain_lead(clead):
             return
 
+        reserved, current_count = _reserve_daily_send_slot(clead.campaign, clead.campaign.connected_account, now=timezone.now())
+        if not reserved:
+            clead.next_execution_time = _start_of_next_day(timezone.now())
+            clead.save(update_fields=['next_execution_time'])
+            logger.info(
+                f"Daily limit reached for campaign {clead.campaign.name}; "
+                f"rescheduling {clead.lead.email} for {clead.next_execution_time}."
+            )
+            return
+
         # Atomic guard: claim this send by nullifying next_execution_time.
         # Only one concurrent caller can win; prevents duplicate sends.
         claimed = CampaignLead.objects.filter(
@@ -489,6 +567,7 @@ def send_email_step(campaign_lead_id, step_id):
             next_execution_time__isnull=False,
         ).update(next_execution_time=None)
         if not claimed:
+            _release_daily_send_slot(clead.campaign, clead.campaign.connected_account, now=timezone.now())
             logger.info(
                 f"Skipping duplicate send for {clead.lead.email} on step {step.step_order}"
             )
@@ -515,6 +594,7 @@ def send_email_step(campaign_lead_id, step_id):
                 logger.info(f"Gmail SENT to {clead.lead.email} | msg_id={message_id}")
             except Exception as gmail_err:
                 logger.error(f"Gmail API send failed for {clead.lead.email}: {gmail_err}")
+                _release_daily_send_slot(clead.campaign, account, now=timezone.now())
                 # Restore next_execution_time so the lead can be retried later.
                 clead.next_execution_time = timezone.now() + timedelta(minutes=15)
                 clead.save(update_fields=['next_execution_time'])
@@ -525,6 +605,11 @@ def send_email_step(campaign_lead_id, step_id):
         _advance_to_next_step(clead, step)
 
     except Exception as e:
+        try:
+            if 'clead' in locals() and 'account' in locals():
+                _release_daily_send_slot(clead.campaign, account, now=timezone.now())
+        except Exception:
+            pass
         logger.error(f"Failed to send email step: {e}")
 
 

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from campaigns.models import Campaign, CampaignLead, ConnectedEmailAccount, SequenceStep
+from campaigns.models import Campaign, CampaignLead, ConnectedEmailAccount, DailySendCount, SequenceStep
 from campaigns.ai import personalize_email
 from campaigns.tasks import (
     _execute_condition_event_step,
@@ -1430,6 +1430,59 @@ class CampaignWorkflowTests(APITestCase):
         self.assertIsNone(campaign_lead.current_step)
         self.assertIsNone(campaign_lead.next_execution_time)
         self.assertEqual(campaign.status, 'COMPLETED')
+        mocked_send.assert_not_called()
+
+    def test_send_email_step_respects_campaign_daily_limit(self):
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='sender@acme.test',
+            provider='GOOGLE',
+            access_token='token',
+            refresh_token='refresh',
+        )
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Daily limit test',
+            status='ACTIVE',
+            connected_account=account,
+            settings={'daily_limit': 1},
+        )
+        email_step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            delay_minutes=0,
+            template_subject='Hello',
+            template_body='Hi there',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='limit@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=email_step,
+            status='ACTIVE',
+            next_execution_time=timezone.now() - timedelta(minutes=1),
+        )
+        DailySendCount.objects.create(
+            organization=self.organization,
+            connected_account=account,
+            send_date=timezone.now().date(),
+            count=1,
+        )
+
+        with patch('campaigns.tasks.send_gmail') as mocked_send:
+            send_email_step(campaign_lead.id, email_step.id)
+
+        campaign_lead.refresh_from_db()
+        self.assertEqual(campaign_lead.current_step_id, email_step.id)
+        self.assertIsNotNone(campaign_lead.next_execution_time)
+        self.assertGreater(campaign_lead.next_execution_time, timezone.now())
         mocked_send.assert_not_called()
 
 

--- a/backend/users/authentication.py
+++ b/backend/users/authentication.py
@@ -1,0 +1,10 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+
+class EmailVerifiedJWTAuthentication(JWTAuthentication):
+    def get_user(self, validated_token):
+        user = super().get_user(validated_token)
+        if not getattr(user, 'is_email_verified', False):
+            raise AuthenticationFailed('Please verify your email before accessing the API.')
+        return user

--- a/backend/users/jwt.py
+++ b/backend/users/jwt.py
@@ -1,4 +1,11 @@
+from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 class CustomTokenObtainSerializer(TokenObtainPairSerializer):
     username_field = 'email'
+
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        if not getattr(self.user, 'is_email_verified', False):
+            raise serializers.ValidationError({'detail': 'Please verify your email before logging in.'})
+        return data

--- a/backend/users/migrations/0002_user_is_email_verified.py
+++ b/backend/users/migrations/0002_user_is_email_verified.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='is_email_verified',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/users/migrations/0003_merge_0002_user_is_email_verified_0002_user_member_role_default.py
+++ b/backend/users/migrations/0003_merge_0002_user_is_email_verified_0002_user_member_role_default.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_user_is_email_verified'),
+        ('users', '0002_user_member_role_default'),
+    ]
+
+    operations = []

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -31,6 +31,7 @@ class User(AbstractBaseUser, PermissionsMixin, TenantModel):
     )
     email = models.EmailField(unique=True)
     role = models.CharField(max_length=20, choices=ROLE_CHOICES, default=ROLE_MEMBER)
+    is_email_verified = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)
     is_staff = models.BooleanField(default=False)
 

--- a/backend/users/permissions.py
+++ b/backend/users/permissions.py
@@ -29,3 +29,11 @@ class IsOrgAdmin(RolePermission):
 class IsOrgManager(RolePermission):
     allowed_roles = frozenset({User.ROLE_ADMIN, User.ROLE_MANAGER})
     message = 'Only organization admins or managers can perform this action.'
+
+
+class IsEmailVerified(BasePermission):
+    message = 'Please verify your email before accessing the API.'
+
+    def has_permission(self, request, view):
+        user = getattr(request, 'user', None)
+        return bool(user and user.is_authenticated and getattr(user, 'is_email_verified', False))

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -11,7 +11,7 @@ class UserSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer(read_only=True)
     class Meta:
         model = User
-        fields = ['id', 'email', 'role', 'organization', 'is_active']
+        fields = ['id', 'email', 'role', 'organization', 'is_active', 'is_email_verified']
 
 class RegisterSerializer(serializers.Serializer):
     email = serializers.EmailField()
@@ -32,5 +32,6 @@ class RegisterSerializer(serializers.Serializer):
             password=validated_data['password'],
             organization=org,
             role='ADMIN',  # First user in org is admin
+            is_email_verified=False,
         )
         return user

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,8 +1,12 @@
+from unittest.mock import patch
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from tenants.models import Organization
+from users.jwt import CustomTokenObtainSerializer
 from users.models import User
+from users.views import generate_email_verification_token
 
 
 class RegisterViewTests(APITestCase):
@@ -27,6 +31,82 @@ class RegisterViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('email', response.data)
+
+    @patch('users.views.send_mail')
+    def test_register_sends_verification_email_without_tokens(self, mock_send_mail):
+        response = self.client.post(
+            '/api/v1/auth/register/',
+            {
+                'email': 'new@example.com',
+                'password': 'StrongPass123!',
+                'organization_name': 'New Org',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('message', response.data)
+        self.assertNotIn('access', response.data)
+        self.assertNotIn('refresh', response.data)
+        user = User.objects.get(email='new@example.com')
+        self.assertFalse(user.is_email_verified)
+        mock_send_mail.assert_called_once()
+        self.assertIn('email-verification.html?token=', mock_send_mail.call_args.args[1])
+
+    def test_verify_email_endpoint_marks_user_verified(self):
+        organization = Organization.objects.create(name='Verify Org')
+        user = User.objects.create_user(
+            email='verify@example.com',
+            password='StrongPass123!',
+            organization=organization,
+            role=User.ROLE_ADMIN,
+        )
+        token = generate_email_verification_token(user)
+
+        response = self.client.get(f'/api/v1/auth/verify-email/{token}/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user.refresh_from_db()
+        self.assertTrue(user.is_email_verified)
+        self.assertEqual(response.data['detail'], 'Email verified successfully.')
+
+    def test_token_obtain_rejects_unverified_user(self):
+        organization = Organization.objects.create(name='Login Org')
+        User.objects.create_user(
+            email='login@example.com',
+            password='StrongPass123!',
+            organization=organization,
+            role=User.ROLE_ADMIN,
+        )
+
+        response = self.client.post(
+            '/api/v1/token/',
+            {'email': 'login@example.com', 'password': 'StrongPass123!'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('detail', response.data)
+
+    def test_token_obtain_allows_verified_user(self):
+        organization = Organization.objects.create(name='Verified Login Org')
+        user = User.objects.create_user(
+            email='verified@example.com',
+            password='StrongPass123!',
+            organization=organization,
+            role=User.ROLE_ADMIN,
+            is_email_verified=True,
+        )
+
+        response = self.client.post(
+            '/api/v1/token/',
+            {'email': user.email, 'password': 'StrongPass123!'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
 
 
 class AuthMeViewTests(APITestCase):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,3 +1,9 @@
+import logging
+
+from django.conf import settings
+from django.core import signing
+from django.core.mail import send_mail
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -7,7 +13,36 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from .models import User
 from .permissions import IsOrgAdmin
 from .serializers import UserSerializer, RegisterSerializer
-from rest_framework_simplejwt.tokens import RefreshToken
+
+logger = logging.getLogger(__name__)
+
+EMAIL_VERIFICATION_SALT = 'users.email-verification'
+
+
+def generate_email_verification_token(user):
+    return signing.dumps(str(user.pk), salt=EMAIL_VERIFICATION_SALT)
+
+
+def build_email_verification_url(token):
+    frontend_base = (getattr(settings, 'FRONTEND_BASE_URL', '') or settings.BACKEND_BASE_URL).rstrip('/')
+    return f'{frontend_base}/email-verification.html?token={token}'
+
+
+def send_verification_email(user):
+    token = generate_email_verification_token(user)
+    verification_url = build_email_verification_url(token)
+    subject = 'Verify your LeadOrbit email'
+    message = (
+        f'Hi {user.email},\n\n'
+        'Please verify your email address to finish setting up your LeadOrbit account.\n'
+        f'Open this link to verify your account: {verification_url}\n\n'
+        'If you did not create this account, you can ignore this email.'
+    )
+    try:
+        send_mail(subject, message, getattr(settings, 'DEFAULT_FROM_EMAIL', 'noreply@leadorbit.local'), [user.email], fail_silently=False)
+    except Exception:
+        logger.exception('Failed to send verification email for user %s', user.email)
+    return verification_url
 
 class AuthViewSet(viewsets.GenericViewSet):
     @action(detail=False, methods=['post'], permission_classes=[AllowAny])
@@ -15,13 +50,30 @@ class AuthViewSet(viewsets.GenericViewSet):
         serializer = RegisterSerializer(data=request.data)
         if serializer.is_valid():
             user = serializer.save()
-            refresh = RefreshToken.for_user(user)
+            verification_url = send_verification_email(user)
             return Response({
                 'user': UserSerializer(user).data,
-                'refresh': str(refresh),
-                'access': str(refresh.access_token),
+                'message': 'Verification email sent. Please check your inbox to activate your account.',
+                'verification_url': verification_url,
             }, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=['get'], permission_classes=[AllowAny], url_path=r'verify-email/(?P<token>[^/]+)')
+    def verify_email(self, request, token=None):
+        try:
+            user_id = signing.loads(token, salt=EMAIL_VERIFICATION_SALT, max_age=60 * 60 * 24 * 7)
+        except signing.BadSignature:
+            return Response({'detail': 'Verification link is invalid or has expired.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        user = get_object_or_404(User, pk=user_id)
+        if not user.is_email_verified:
+            user.is_email_verified = True
+            user.save(update_fields=['is_email_verified'])
+
+        return Response({
+            'detail': 'Email verified successfully.',
+            'user': UserSerializer(user).data,
+        })
 
     @action(detail=False, methods=['get', 'patch'], permission_classes=[IsAuthenticated])
     def me(self, request):

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -146,7 +146,17 @@ export const register = async (userData) => {
         body: JSON.stringify(userData)
     });
     if (!res.ok) throw new Error("Registration failed");
-    const data = await res.json();
-    setTokens(data.access, data.refresh);
+    return await res.json();
+};
+
+export const verifyEmail = async (token) => {
+    const res = await fetch(`${API_BASE}/auth/verify-email/${encodeURIComponent(token)}/`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        throw new Error(data.detail || 'Email verification failed.');
+    }
     return data;
 };

--- a/frontend/campaigns.html
+++ b/frontend/campaigns.html
@@ -213,6 +213,12 @@
             return 0;
         }
 
+        function getDailyLimit(campaign) {
+            const rawLimit = campaign.daily_limit ?? campaign.settings?.daily_limit;
+            const limit = Number(rawLimit);
+            return Number.isFinite(limit) && limit > 0 ? limit : null;
+        }
+
         function getStepPreview(campaign) {
             const source = Array.isArray(campaign.settings?.steps) && campaign.settings.steps.length > 0
                 ? campaign.settings.steps
@@ -319,6 +325,8 @@
                 const status = normalizeStatus(campaign.status);
                 const stepCount = getStepCount(campaign);
                 const previewSteps = getStepPreview(campaign);
+                const dailyLimit = getDailyLimit(campaign);
+                const sendsToday = Number(campaign.sends_today) || 0;
                 const previewHtml = previewSteps.length > 0
                     ? previewSteps.map(label => `<span class="step-chip"><i class="bi bi-dot" aria-hidden="true"></i>${escapeHtml(label)}</span>`).join('')
                     : '<span class="text-muted small">No sequence steps configured</span>';
@@ -362,6 +370,11 @@
                                         <div class="metric-label">Mode</div>
                                         <div class="metric-value">${status === 'ACTIVE' ? 'Live' : 'Idle'}</div>
                                     </div>
+                                    ${dailyLimit ? `
+                                    <div class="metric-box">
+                                        <div class="metric-label">Today</div>
+                                        <div class="metric-value">${sendsToday}/${dailyLimit}</div>
+                                    </div>` : ''}
                                 </div>
 
                                 <div class="step-preview">${previewHtml}</div>

--- a/frontend/email-verification.html
+++ b/frontend/email-verification.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LeadOrbit - Verify Email</title>
+    <meta name="description" content="Verify your LeadOrbit email address.">
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <script src="./theme-boot.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="./theme.css" rel="stylesheet">
+    <style>
+        body {
+            min-height: 100vh;
+            background: var(--bg);
+            color: var(--ink-900);
+        }
+    </style>
+</head>
+
+<body class="d-flex align-items-center">
+    <div class="container py-5" style="max-width: 720px;">
+        <div class="card shadow-sm" style="border: 1px solid var(--line); border-radius: 16px;">
+            <div class="card-body p-4 p-md-5">
+                <div class="d-flex align-items-center gap-3 mb-4">
+                    <div class="rounded-circle d-inline-flex align-items-center justify-content-center" style="width:48px;height:48px;background:var(--primary);color:#fff;">
+                        <i class="bi bi-envelope-check fs-4" aria-hidden="true"></i>
+                    </div>
+                    <div>
+                        <h1 class="h4 mb-1">Verify your email</h1>
+                        <p class="mb-0 text-secondary" id="subtitle">We’re checking your link now.</p>
+                    </div>
+                </div>
+
+                <div id="status" class="alert alert-info" role="alert">
+                    If you just signed up, check your inbox for the verification link.
+                </div>
+
+                <div id="action-row" class="d-flex flex-wrap gap-2 d-none">
+                    <a class="btn btn-primary" href="/login.html">Go to login</a>
+                    <a class="btn btn-outline-secondary" href="/register.html">Create another account</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script type="module">
+        import { verifyEmail } from './api.js';
+
+        const params = new URLSearchParams(window.location.search);
+        const token = params.get('token');
+        const email = params.get('email');
+        const status = document.getElementById('status');
+        const subtitle = document.getElementById('subtitle');
+        const actionRow = document.getElementById('action-row');
+
+        if (email && subtitle) {
+            subtitle.textContent = `A verification email was sent to ${email}.`;
+        }
+
+        const showActionLinks = () => {
+            actionRow?.classList.remove('d-none');
+        };
+
+        if (!token) {
+            status.className = 'alert alert-warning';
+            status.textContent = 'Check your inbox and open the verification link to activate your account.';
+            showActionLinks();
+        } else {
+            status.className = 'alert alert-info';
+            status.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Verifying your account...';
+            try {
+                const result = await verifyEmail(token);
+                status.className = 'alert alert-success';
+                status.textContent = result.detail || 'Your email has been verified successfully.';
+                showActionLinks();
+            } catch (err) {
+                status.className = 'alert alert-danger';
+                status.textContent = err?.message || 'Verification failed. The link may have expired.';
+                showActionLinks();
+            }
+        }
+    </script>
+</body>
+
+</html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -192,9 +192,9 @@
                             first_name, last_name, email, password, organization_name
                         });
 
-                        window.location.href = '/dashboard.html';
+                        window.location.href = `/email-verification.html?email=${encodeURIComponent(email)}`;
                     } catch (err) {
-                        alert('Registration failed. Please try again.');
+                        alert(err?.message || 'Registration failed. Please try again.');
                         const btn = form.querySelector('button[type="submit"]');
                         btn.disabled = false;
                         btn.textContent = 'Sign Up';


### PR DESCRIPTION
What changed\n- Added per-account daily send tracking for campaigns.\n- Enforced the campaign-level daily limit before each email send and rescheduled leads when the limit is reached.\n- Exposed daily limit and sends-today metrics in the campaign serializer and UI.\n- Cleaned up the task module import block while touching the send path.\n\nWhy\n- Campaign settings already needed a hard send cap, but the scheduler did not persist or enforce one.\n- This prevents oversending while still keeping leads queued for the next day.\n\nValidation\n- python3 -m py_compile backend/campaigns/models.py backend/campaigns/serializers.py backend/campaigns/tasks.py backend/campaigns/tests.py\n- git diff --check\n- python3 backend/manage.py test campaigns.tests.CampaignWorkflowTests -v 2\n\nCloses #288