### PR TITLE
fix redis-backed API rate limiting

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -171,6 +171,12 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
 }
 
+# Redis URL used by the rate limiter; falls back to the Celery broker when available.
+RATE_LIMIT_REDIS_URL = os.getenv(
+    'RATE_LIMIT_REDIS_URL',
+    os.getenv('REDIS_URL', os.getenv('CELERY_BROKER_URL', '')),
+)
+
 # Allow all origins in development
 CORS_ALLOW_ALL_ORIGINS = True
 

--- a/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0009_campaign_cached_counters'),
+        ('campaigns', '0009_campaignlead_bounce_metadata'),
+    ]
+
+    operations = []

--- a/backend/tenants/security.py
+++ b/backend/tenants/security.py
@@ -1,45 +1,132 @@
 """
 Security middleware for rate limiting and request hardening.
 """
-import time
 import logging
+import time
+
+try:
+    import redis
+except ImportError:  # pragma: no cover - local fallback handles this case
+    redis = None
+
+from django.conf import settings as django_settings
 from django.http import JsonResponse
 from django.utils.deprecation import MiddlewareMixin
 
 logger = logging.getLogger(__name__)
 
+
 class RateLimitMiddleware(MiddlewareMixin):
     """
-    Simple in-memory rate limiter for API endpoints.
-    Limits each IP to a max number of requests per window.
+    API rate limiter backed by Redis when available.
+
+    Falls back to a per-process in-memory store when Redis is unavailable so
+    local development still works without hard failures.
     """
-    # { ip_address: [timestamp1, timestamp2, ...] }
+
     _requests = {}
-    MAX_REQUESTS = 100  # per window
+    _redis_client = None
+    _redis_client_checked = False
+
+    DEFAULT_MAX_REQUESTS = 100
+    LOGIN_MAX_REQUESTS = 20
+    REGISTER_MAX_REQUESTS = 10
     WINDOW_SECONDS = 60
+    REDIS_URL_SETTING = 'RATE_LIMIT_REDIS_URL'
 
     def process_request(self, request):
         if not request.path.startswith('/api/'):
             return None
 
         ip = self._get_client_ip(request)
-        now = time.time()
-
-        # Clean old entries
-        if ip in self._requests:
-            self._requests[ip] = [t for t in self._requests[ip] if now - t < self.WINDOW_SECONDS]
-        else:
-            self._requests[ip] = []
-
-        if len(self._requests[ip]) >= self.MAX_REQUESTS:
+        limit_name, max_requests = self._get_limit_for_path(request.path)
+        allowed, retry_after = self._is_request_allowed(limit_name, ip, max_requests)
+        if not allowed:
             logger.warning(f"Rate limit exceeded for IP: {ip}")
-            return JsonResponse(
-                {'error': 'Too many requests. Please slow down.'},
-                status=429
-            )
+            payload = {'error': 'Too many requests. Please slow down.'}
+            if retry_after is not None:
+                payload['retry_after_seconds'] = retry_after
+            response = JsonResponse(payload, status=429)
+            if retry_after is not None:
+                response['Retry-After'] = str(retry_after)
+            return response
 
-        self._requests[ip].append(now)
         return None
+
+    def _get_limit_for_path(self, path):
+        normalized_path = path.rstrip('/') or '/'
+        if normalized_path == '/api/v1/auth/login':
+            return 'login', self.LOGIN_MAX_REQUESTS
+        if normalized_path == '/api/v1/auth/register':
+            return 'register', self.REGISTER_MAX_REQUESTS
+        return 'default', self.DEFAULT_MAX_REQUESTS
+
+    def _is_request_allowed(self, limit_name, ip, max_requests):
+        redis_client = self._get_redis_client()
+        if redis_client is not None:
+            return self._check_redis_limit(redis_client, limit_name, ip, max_requests)
+        return self._check_local_limit(limit_name, ip, max_requests)
+
+    def _get_redis_client(self):
+        if self._redis_client_checked:
+            return self._redis_client
+
+        self._redis_client_checked = True
+
+        if redis is None:
+            logger.info('Redis library is unavailable; using local rate limiting fallback.')
+            return None
+
+        redis_url = (
+            getattr(django_settings, self.REDIS_URL_SETTING, '')
+            or getattr(django_settings, 'REDIS_URL', '')
+            or getattr(django_settings, 'CELERY_BROKER_URL', '')
+        )
+        if not redis_url.startswith(('redis://', 'rediss://')):
+            logger.info('No Redis URL configured for rate limiting; using local fallback.')
+            return None
+
+        try:
+            client = redis.Redis.from_url(
+                redis_url,
+                decode_responses=True,
+                socket_connect_timeout=0.5,
+                socket_timeout=0.5,
+            )
+            client.ping()
+            self._redis_client = client
+            return client
+        except Exception as exc:  # pragma: no cover - depends on the runtime env
+            logger.warning('Redis rate limiter unavailable, using local fallback: %s', exc)
+            self._redis_client = None
+            return None
+
+    def _check_redis_limit(self, client, limit_name, ip, max_requests):
+        key = f'rate-limit:{limit_name}:{ip}'
+        count = client.incr(key)
+        if count == 1:
+            client.expire(key, self.WINDOW_SECONDS)
+        if count > max_requests:
+            ttl = client.ttl(key)
+            retry_after = ttl if isinstance(ttl, int) and ttl > 0 else self.WINDOW_SECONDS
+            return False, retry_after
+        return True, None
+
+    def _check_local_limit(self, limit_name, ip, max_requests):
+        now = time.time()
+        key = f'{limit_name}:{ip}'
+        timestamps = self._requests.get(key, [])
+        cutoff = now - self.WINDOW_SECONDS
+        timestamps = [timestamp for timestamp in timestamps if timestamp >= cutoff]
+
+        if len(timestamps) >= max_requests:
+            self._requests[key] = timestamps
+            retry_after = int(max(1, self.WINDOW_SECONDS - (now - timestamps[0])))
+            return False, retry_after
+
+        timestamps.append(now)
+        self._requests[key] = timestamps
+        return True, None
 
     def _get_client_ip(self, request):
         x_forwarded = request.META.get('HTTP_X_FORWARDED_FOR')
@@ -52,6 +139,7 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
     """
     Adds standard security headers to all responses.
     """
+
     def process_response(self, request, response):
         response['X-Content-Type-Options'] = 'nosniff'
         response['X-Frame-Options'] = 'DENY'

--- a/backend/tenants/tests.py
+++ b/backend/tenants/tests.py
@@ -1,3 +1,82 @@
-from django.test import TestCase
+import json
+from unittest.mock import patch
 
-# Create your tests here.
+from django.http import JsonResponse
+from django.test import RequestFactory, TestCase
+
+from tenants.security import RateLimitMiddleware
+
+
+class FakeRedisClient:
+    def __init__(self):
+        self.counts = {}
+        self.expiries = {}
+        self.ttl_value = 60
+
+    def incr(self, key):
+        self.counts[key] = self.counts.get(key, 0) + 1
+        return self.counts[key]
+
+    def expire(self, key, seconds):
+        self.expiries[key] = seconds
+        return True
+
+    def ttl(self, key):
+        return self.ttl_value
+
+
+class RateLimitMiddlewareTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        RateLimitMiddleware._requests = {}
+        RateLimitMiddleware._redis_client = None
+        RateLimitMiddleware._redis_client_checked = False
+
+    def _build_request(self, path='/api/v1/leads/', ip='203.0.113.10'):
+        request = self.factory.get(path)
+        request.META['REMOTE_ADDR'] = ip
+        return request
+
+    def test_non_api_requests_are_ignored(self):
+        middleware = RateLimitMiddleware(lambda request: JsonResponse({'ok': True}))
+
+        response = middleware.process_request(self._build_request(path='/admin/'))
+
+        self.assertIsNone(response)
+
+    def test_login_endpoint_uses_stricter_redis_limit(self):
+        middleware = RateLimitMiddleware(lambda request: JsonResponse({'ok': True}))
+        fake_client = FakeRedisClient()
+        request = self._build_request(path='/api/v1/auth/login/')
+
+        with patch.object(RateLimitMiddleware, 'LOGIN_MAX_REQUESTS', 2), patch.object(
+            RateLimitMiddleware,
+            '_get_redis_client',
+            return_value=fake_client,
+        ):
+            self.assertIsNone(middleware.process_request(request))
+            self.assertIsNone(middleware.process_request(request))
+            response = middleware.process_request(request)
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(json.loads(response.content.decode())['retry_after_seconds'], 60)
+        self.assertIn('rate-limit:login:203.0.113.10', fake_client.expiries)
+
+    def test_local_fallback_expires_old_entries(self):
+        middleware = RateLimitMiddleware(lambda request: JsonResponse({'ok': True}))
+        request = self._build_request()
+
+        with patch.object(RateLimitMiddleware, 'DEFAULT_MAX_REQUESTS', 2), patch.object(
+            RateLimitMiddleware,
+            '_get_redis_client',
+            return_value=None,
+        ), patch('tenants.security.time.time', side_effect=[100.0, 110.0, 171.0, 172.0]):
+            self.assertIsNone(middleware.process_request(request))
+            self.assertIsNone(middleware.process_request(request))
+
+            # The first two timestamps have aged out of the window by the third request.
+            response = middleware.process_request(request)
+
+        self.assertIsNone(response)
+        self.assertEqual(len(RateLimitMiddleware._requests['default:203.0.113.10']), 1)


### PR DESCRIPTION
What changed\n- Replaced the in-memory API rate limiter with a Redis-backed implementation.\n- Added a safe local fallback when Redis is unavailable so development keeps working.\n- Applied stricter limits to login and register endpoints while keeping the default API window in place.\n- Added tests for the Redis path, fallback cleanup, and auth regression coverage.\n- Added the missing campaigns migration merge file needed for Django to load the current migration graph cleanly in tests.\n\nWhy\n- The old in-memory dict was per-worker, so rate limits were not global and could grow without bound.\n- Login and register deserve stricter throttling than general API traffic.\n\nValidation\n- python3 -m py_compile backend/tenants/security.py backend/backend/settings.py backend/tenants/tests.py backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py\n- git diff --check\n- python3 backend/manage.py test tenants.tests -v 2\n- python3 backend/manage.py test users.tests -v 2\n\nCloses #336