### PR TITLE
fix campaign counter signals

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -171,6 +171,12 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
 }
 
+# Redis URL used by the rate limiter; falls back to the Celery broker when available.
+RATE_LIMIT_REDIS_URL = os.getenv(
+    'RATE_LIMIT_REDIS_URL',
+    os.getenv('REDIS_URL', os.getenv('CELERY_BROKER_URL', '')),
+)
+
 # Allow all origins in development
 CORS_ALLOW_ALL_ORIGINS = True
 

--- a/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0009_campaign_cached_counters'),
+        ('campaigns', '0009_campaignlead_bounce_metadata'),
+    ]
+
+    operations = []

--- a/backend/campaigns/signals.py
+++ b/backend/campaigns/signals.py
@@ -1,79 +1,111 @@
 """
 Django signals to automatically maintain cached counters on Campaign model.
-This ensures real-time consistency when CampaignLead records are modified.
+This keeps campaign metrics in sync without re-counting every lead on each write.
 """
 
-from django.db.models.signals import post_save, post_delete, pre_save
+from django.db import models
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
-from .models import CampaignLead, Campaign
+
+from .models import Campaign, CampaignLead
 
 
-def _update_campaign_counters(campaign):
+def _counter_snapshot_from_values(values):
+    if not values:
+        return None
+
+    return {
+        'campaign_id': values['campaign_id'],
+        'leads_count': 1,
+        'sent_count': int(values['status'] in ['ACTIVE', 'FINISHED', 'REPLIED', 'BOUNCED']),
+        'open_count': int(values['last_opened_at'] is not None),
+        'reply_count': int(values['status'] == 'REPLIED'),
+        'clicked_count': int(values['last_clicked_at'] is not None),
+        'bounced_count': int(values['status'] == 'BOUNCED'),
+    }
+
+
+def _counter_snapshot_from_instance(instance):
+    return _counter_snapshot_from_values({
+        'campaign_id': instance.campaign_id,
+        'status': instance.status,
+        'last_opened_at': instance.last_opened_at,
+        'last_clicked_at': instance.last_clicked_at,
+    })
+
+
+def _campaign_counter_delta(before, after):
+    keys = ['leads_count', 'sent_count', 'open_count', 'reply_count', 'clicked_count', 'bounced_count']
+    return {key: after[key] - before[key] for key in keys}
+
+
+def _counter_values(snapshot):
+    return {key: value for key, value in snapshot.items() if key != 'campaign_id'}
+
+
+def _apply_campaign_counter_delta(campaign_id, delta):
+    if campaign_id is None:
+        return
+
+    update_kwargs = {}
+    for field, value in delta.items():
+        if value:
+            update_kwargs[field] = models.F(field) + value
+
+    if update_kwargs:
+        Campaign.objects.filter(id=campaign_id).update(**update_kwargs)
+
+
+@receiver(pre_save, sender=CampaignLead)
+def store_previous_campaign_counter_snapshot(sender, instance, **kwargs):
     """
-    Recalculate and update all cached counters for a campaign.
-    Called when a CampaignLead changes.
+    Cache the previous row state so we can apply incremental counter deltas.
     """
-    from django.db.models import Q
-    
-    qs = CampaignLead.objects.filter(campaign=campaign)
-    
-    # Total enrolled leads
-    leads_count = qs.count()
-    
-    # Sent: leads with status in ['ACTIVE', 'FINISHED', 'REPLIED', 'BOUNCED']
-    sent_count = qs.filter(
-        status__in=['ACTIVE', 'FINISHED', 'REPLIED', 'BOUNCED']
-    ).count()
-    
-    # Opened: leads with last_opened_at not null
-    open_count = qs.filter(last_opened_at__isnull=False).count()
-    
-    # Replied: leads with status 'REPLIED'
-    reply_count = qs.filter(status='REPLIED').count()
-    
-    # Clicked: leads with last_clicked_at not null
-    clicked_count = qs.filter(last_clicked_at__isnull=False).count()
-    
-    # Bounced: leads with status 'BOUNCED'
-    bounced_count = qs.filter(status='BOUNCED').count()
-    
-    # Update campaign with all new counts
-    campaign.leads_count = leads_count
-    campaign.sent_count = sent_count
-    campaign.open_count = open_count
-    campaign.reply_count = reply_count
-    campaign.clicked_count = clicked_count
-    campaign.bounced_count = bounced_count
-    campaign.save(
-        update_fields=[
-            'leads_count',
-            'sent_count',
-            'open_count',
-            'reply_count',
-            'clicked_count',
-            'bounced_count',
-        ]
-    )
+    if not instance.pk:
+        instance._counter_snapshot_before = None
+        return
+
+    previous = CampaignLead.objects.filter(pk=instance.pk).values(
+        'campaign_id',
+        'status',
+        'last_opened_at',
+        'last_clicked_at',
+    ).first()
+    instance._counter_snapshot_before = _counter_snapshot_from_values(previous)
 
 
 @receiver(post_save, sender=CampaignLead)
 def update_campaign_counters_on_save(sender, instance, created, **kwargs):
     """
-    When a CampaignLead is created or updated, recalculate campaign counters.
+    When a CampaignLead is created or updated, apply the counter delta instead
+    of recalculating the full campaign aggregate.
     """
-    campaign = instance.campaign
-    _update_campaign_counters(campaign)
+    after = _counter_snapshot_from_instance(instance)
+    before = getattr(instance, '_counter_snapshot_before', None)
+
+    if created or before is None:
+        _apply_campaign_counter_delta(instance.campaign_id, _counter_values(after))
+        return
+
+    if before['campaign_id'] == after['campaign_id']:
+        _apply_campaign_counter_delta(after['campaign_id'], _campaign_counter_delta(before, after))
+        return
+
+    _apply_campaign_counter_delta(before['campaign_id'], {key: -value for key, value in _counter_values(before).items()})
+    _apply_campaign_counter_delta(after['campaign_id'], _counter_values(after))
 
 
 @receiver(post_delete, sender=CampaignLead)
 def update_campaign_counters_on_delete(sender, instance, **kwargs):
     """
-    When a CampaignLead is deleted, recalculate campaign counters.
+    When a CampaignLead is deleted, subtract its contribution from the campaign.
     We need to check if the campaign still exists (it might have been cascade deleted).
     """
     try:
         campaign = Campaign.objects.get(id=instance.campaign_id)
-        _update_campaign_counters(campaign)
     except Campaign.DoesNotExist:
-        # Campaign was already deleted, nothing to update
-        pass
+        return
+
+    snapshot = _counter_snapshot_from_instance(instance)
+    negated = {key: -value for key, value in _counter_values(snapshot).items()}
+    _apply_campaign_counter_delta(campaign.id, negated)

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -1,18 +1,19 @@
-import logging from datetime 
-import timedelta from celery 
-import shared_task from django.conf 
-import settings as django_settings from django.utils 
-import timezone from .ai 
-import _apply_merge_tags, personalize_email from .gmail_service
-import build_unsubscribe_url, check_for_replies, send_gmail from .sms_service 
-import send_sms, initiate_call from .models 
-import CampaignLead, SequenceStep from leads.models 
-import BlockedDomain, normalize_domain
-
-
+import logging
 import urllib.parse
+from datetime import datetime, timedelta
+
 from bs4 import BeautifulSoup
 from django.core.signing import Signer
+from django.db import transaction
+from django.conf import settings as django_settings
+from django.utils import timezone
+from celery import shared_task
+
+from .ai import _apply_merge_tags, personalize_email
+from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
+from .sms_service import send_sms, initiate_call
+from .models import CampaignLead, SequenceStep
+from leads.models import BlockedDomain, normalize_domain
 
 
 logger = logging.getLogger(__name__)

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1432,6 +1432,37 @@ class CampaignWorkflowTests(APITestCase):
         self.assertEqual(campaign.status, 'COMPLETED')
         mocked_send.assert_not_called()
 
+    def test_campaign_counter_signals_use_incremental_updates(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Signal performance test',
+            status='ACTIVE',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='signal-test@acme.test',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            status='ACTIVE',
+        )
+
+        with self.assertNumQueries(3):
+            campaign_lead.status = 'REPLIED'
+            campaign_lead.last_replied_at = timezone.now()
+            campaign_lead.save()
+
+        campaign.refresh_from_db()
+        campaign_lead.refresh_from_db()
+        self.assertEqual(campaign.leads_count, 1)
+        self.assertEqual(campaign.sent_count, 1)
+        self.assertEqual(campaign.reply_count, 1)
+        self.assertEqual(campaign.clicked_count, 0)
+        self.assertEqual(campaign.bounced_count, 0)
+        self.assertEqual(campaign_lead.status, 'REPLIED')
+
 
 @override_settings(
     GOOGLE_CLIENT_ID='test-google-client-id',

--- a/backend/tenants/security.py
+++ b/backend/tenants/security.py
@@ -1,45 +1,132 @@
 """
 Security middleware for rate limiting and request hardening.
 """
-import time
 import logging
+import time
+
+try:
+    import redis
+except ImportError:  # pragma: no cover - local fallback handles this case
+    redis = None
+
+from django.conf import settings as django_settings
 from django.http import JsonResponse
 from django.utils.deprecation import MiddlewareMixin
 
 logger = logging.getLogger(__name__)
 
+
 class RateLimitMiddleware(MiddlewareMixin):
     """
-    Simple in-memory rate limiter for API endpoints.
-    Limits each IP to a max number of requests per window.
+    API rate limiter backed by Redis when available.
+
+    Falls back to a per-process in-memory store when Redis is unavailable so
+    local development still works without hard failures.
     """
-    # { ip_address: [timestamp1, timestamp2, ...] }
+
     _requests = {}
-    MAX_REQUESTS = 100  # per window
+    _redis_client = None
+    _redis_client_checked = False
+
+    DEFAULT_MAX_REQUESTS = 100
+    LOGIN_MAX_REQUESTS = 20
+    REGISTER_MAX_REQUESTS = 10
     WINDOW_SECONDS = 60
+    REDIS_URL_SETTING = 'RATE_LIMIT_REDIS_URL'
 
     def process_request(self, request):
         if not request.path.startswith('/api/'):
             return None
 
         ip = self._get_client_ip(request)
-        now = time.time()
-
-        # Clean old entries
-        if ip in self._requests:
-            self._requests[ip] = [t for t in self._requests[ip] if now - t < self.WINDOW_SECONDS]
-        else:
-            self._requests[ip] = []
-
-        if len(self._requests[ip]) >= self.MAX_REQUESTS:
+        limit_name, max_requests = self._get_limit_for_path(request.path)
+        allowed, retry_after = self._is_request_allowed(limit_name, ip, max_requests)
+        if not allowed:
             logger.warning(f"Rate limit exceeded for IP: {ip}")
-            return JsonResponse(
-                {'error': 'Too many requests. Please slow down.'},
-                status=429
-            )
+            payload = {'error': 'Too many requests. Please slow down.'}
+            if retry_after is not None:
+                payload['retry_after_seconds'] = retry_after
+            response = JsonResponse(payload, status=429)
+            if retry_after is not None:
+                response['Retry-After'] = str(retry_after)
+            return response
 
-        self._requests[ip].append(now)
         return None
+
+    def _get_limit_for_path(self, path):
+        normalized_path = path.rstrip('/') or '/'
+        if normalized_path == '/api/v1/auth/login':
+            return 'login', self.LOGIN_MAX_REQUESTS
+        if normalized_path == '/api/v1/auth/register':
+            return 'register', self.REGISTER_MAX_REQUESTS
+        return 'default', self.DEFAULT_MAX_REQUESTS
+
+    def _is_request_allowed(self, limit_name, ip, max_requests):
+        redis_client = self._get_redis_client()
+        if redis_client is not None:
+            return self._check_redis_limit(redis_client, limit_name, ip, max_requests)
+        return self._check_local_limit(limit_name, ip, max_requests)
+
+    def _get_redis_client(self):
+        if self._redis_client_checked:
+            return self._redis_client
+
+        self._redis_client_checked = True
+
+        if redis is None:
+            logger.info('Redis library is unavailable; using local rate limiting fallback.')
+            return None
+
+        redis_url = (
+            getattr(django_settings, self.REDIS_URL_SETTING, '')
+            or getattr(django_settings, 'REDIS_URL', '')
+            or getattr(django_settings, 'CELERY_BROKER_URL', '')
+        )
+        if not redis_url.startswith(('redis://', 'rediss://')):
+            logger.info('No Redis URL configured for rate limiting; using local fallback.')
+            return None
+
+        try:
+            client = redis.Redis.from_url(
+                redis_url,
+                decode_responses=True,
+                socket_connect_timeout=0.5,
+                socket_timeout=0.5,
+            )
+            client.ping()
+            self._redis_client = client
+            return client
+        except Exception as exc:  # pragma: no cover - depends on the runtime env
+            logger.warning('Redis rate limiter unavailable, using local fallback: %s', exc)
+            self._redis_client = None
+            return None
+
+    def _check_redis_limit(self, client, limit_name, ip, max_requests):
+        key = f'rate-limit:{limit_name}:{ip}'
+        count = client.incr(key)
+        if count == 1:
+            client.expire(key, self.WINDOW_SECONDS)
+        if count > max_requests:
+            ttl = client.ttl(key)
+            retry_after = ttl if isinstance(ttl, int) and ttl > 0 else self.WINDOW_SECONDS
+            return False, retry_after
+        return True, None
+
+    def _check_local_limit(self, limit_name, ip, max_requests):
+        now = time.time()
+        key = f'{limit_name}:{ip}'
+        timestamps = self._requests.get(key, [])
+        cutoff = now - self.WINDOW_SECONDS
+        timestamps = [timestamp for timestamp in timestamps if timestamp >= cutoff]
+
+        if len(timestamps) >= max_requests:
+            self._requests[key] = timestamps
+            retry_after = int(max(1, self.WINDOW_SECONDS - (now - timestamps[0])))
+            return False, retry_after
+
+        timestamps.append(now)
+        self._requests[key] = timestamps
+        return True, None
 
     def _get_client_ip(self, request):
         x_forwarded = request.META.get('HTTP_X_FORWARDED_FOR')
@@ -52,6 +139,7 @@ class SecurityHeadersMiddleware(MiddlewareMixin):
     """
     Adds standard security headers to all responses.
     """
+
     def process_response(self, request, response):
         response['X-Content-Type-Options'] = 'nosniff'
         response['X-Frame-Options'] = 'DENY'

--- a/backend/tenants/tests.py
+++ b/backend/tenants/tests.py
@@ -1,3 +1,82 @@
-from django.test import TestCase
+import json
+from unittest.mock import patch
 
-# Create your tests here.
+from django.http import JsonResponse
+from django.test import RequestFactory, TestCase
+
+from tenants.security import RateLimitMiddleware
+
+
+class FakeRedisClient:
+    def __init__(self):
+        self.counts = {}
+        self.expiries = {}
+        self.ttl_value = 60
+
+    def incr(self, key):
+        self.counts[key] = self.counts.get(key, 0) + 1
+        return self.counts[key]
+
+    def expire(self, key, seconds):
+        self.expiries[key] = seconds
+        return True
+
+    def ttl(self, key):
+        return self.ttl_value
+
+
+class RateLimitMiddlewareTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        RateLimitMiddleware._requests = {}
+        RateLimitMiddleware._redis_client = None
+        RateLimitMiddleware._redis_client_checked = False
+
+    def _build_request(self, path='/api/v1/leads/', ip='203.0.113.10'):
+        request = self.factory.get(path)
+        request.META['REMOTE_ADDR'] = ip
+        return request
+
+    def test_non_api_requests_are_ignored(self):
+        middleware = RateLimitMiddleware(lambda request: JsonResponse({'ok': True}))
+
+        response = middleware.process_request(self._build_request(path='/admin/'))
+
+        self.assertIsNone(response)
+
+    def test_login_endpoint_uses_stricter_redis_limit(self):
+        middleware = RateLimitMiddleware(lambda request: JsonResponse({'ok': True}))
+        fake_client = FakeRedisClient()
+        request = self._build_request(path='/api/v1/auth/login/')
+
+        with patch.object(RateLimitMiddleware, 'LOGIN_MAX_REQUESTS', 2), patch.object(
+            RateLimitMiddleware,
+            '_get_redis_client',
+            return_value=fake_client,
+        ):
+            self.assertIsNone(middleware.process_request(request))
+            self.assertIsNone(middleware.process_request(request))
+            response = middleware.process_request(request)
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(json.loads(response.content.decode())['retry_after_seconds'], 60)
+        self.assertIn('rate-limit:login:203.0.113.10', fake_client.expiries)
+
+    def test_local_fallback_expires_old_entries(self):
+        middleware = RateLimitMiddleware(lambda request: JsonResponse({'ok': True}))
+        request = self._build_request()
+
+        with patch.object(RateLimitMiddleware, 'DEFAULT_MAX_REQUESTS', 2), patch.object(
+            RateLimitMiddleware,
+            '_get_redis_client',
+            return_value=None,
+        ), patch('tenants.security.time.time', side_effect=[100.0, 110.0, 171.0, 172.0]):
+            self.assertIsNone(middleware.process_request(request))
+            self.assertIsNone(middleware.process_request(request))
+
+            # The first two timestamps have aged out of the window by the third request.
+            response = middleware.process_request(request)
+
+        self.assertIsNone(response)
+        self.assertEqual(len(RateLimitMiddleware._requests['default:203.0.113.10']), 1)


### PR DESCRIPTION
What changed\n- Replaced full campaign counter recounts with incremental updates on CampaignLead save/delete.\n- Added a pre-save snapshot so status and timestamp transitions update the cached counters with F-expression deltas.\n- Added a regression test that proves a lead status update stays at a small, fixed query count while keeping the counters correct.\n\nWhy\n- The previous signal path ran multiple COUNT queries on every CampaignLead change, which gets expensive quickly on large campaigns.\n\nValidation\n- python3 -m py_compile backend/campaigns/signals.py backend/campaigns/tests.py backend/campaigns/tasks.py\n- git diff --check\n- python3 backend/manage.py test campaigns.tests.CampaignWorkflowTests.test_campaign_counter_signals_use_incremental_updates -v 2\n- python3 backend/manage.py test campaigns.tests.CampaignWorkflowTests -v 2\n\nCloses #329