### PR TITLE
fix: eliminate N+1 queries in dashboard recent activity

### DIFF
--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -600,7 +600,13 @@ class DashboardAnalyticsView(APIView):
 
         # ── Recent activity (real data) ──
         recent = []
-        for cl in CampaignLead.objects.filter(organization=org).order_by('-updated_at')[:10]:
+        for cl in (
+            CampaignLead.objects
+            .filter(organization=org)
+            .select_related('lead', 'campaign')
+            .order_by('-updated_at')[:10]
+        ):
+        
             action = cl.status.lower()
             lead_name = cl.lead.email if cl.lead else 'Unknown'
             recent.append({


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #330

---

## 📝 Summary of Changes

Fixed the N+1 query issue in the Dashboard Analytics recent activity section by adding `select_related('lead', 'campaign')` to the `CampaignLead` queryset.

This ensures that related `Lead` and `Campaign` objects are fetched in a single database query, reducing unnecessary database hits and improving dashboard performance.

---

## 🏷️ Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [x] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

Verified that the recent activity functionality continues to work correctly after the optimization.

**Steps to test:**

1. Run the Django server.
2. Navigate to the Analytics Dashboard.
3. Verify that recent activity entries display correctly.
4. Confirm that lead email and campaign name are loaded without additional per-row database queries.
5. Compare query count before and after the change using Django Debug Toolbar or query inspection.

---

## 📸 Screenshots (if applicable)

N/A

---

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (not required)
* [x] Related issue linked
* [x] Changes tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized dashboard analytics query performance for recent activity data retrieval.

---

**Note:** This release contains internal performance improvements with no visible changes to user-facing functionality or interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->