### PR TITLE
fix: standardize Django logging settings

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -193,6 +193,61 @@ LAUNCH_IMMEDIATE_PASSES = int(os.getenv('LAUNCH_IMMEDIATE_PASSES', '1' if DEBUG 
 # Email backend (console for dev)
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+DJANGO_LOG_LEVEL = os.getenv('DJANGO_LOG_LEVEL', 'DEBUG' if DEBUG else 'INFO').upper()
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '%(levelname)s %(asctime)s %(name)s %(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard',
+            'level': DJANGO_LOG_LEVEL,
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': DJANGO_LOG_LEVEL,
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+            'propagate': False,
+        },
+        'backend': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+            'propagate': False,
+        },
+        'leads': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+            'propagate': False,
+        },
+        'campaigns': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+            'propagate': False,
+        },
+        'tenants': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+            'propagate': False,
+        },
+        'users': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+            'propagate': False,
+        },
+    },
+}
+
 # ─── Google OAuth2 / Gmail API ─────────────────────
 BACKEND_BASE_URL = os.getenv(
     'BACKEND_BASE_URL',

--- a/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0009_campaign_cached_counters'),
+        ('campaigns', '0009_campaignlead_bounce_metadata'),
+    ]
+
+    operations = []

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.test import SimpleTestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -104,3 +106,18 @@ class AuthMeViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue(Organization.objects.filter(id=self.organization.id).exists())
         self.assertTrue(User.objects.filter(id=self.user.id).exists())
+
+
+class LoggingSettingsTests(SimpleTestCase):
+    def test_django_logging_is_standardized(self):
+        logging_config = settings.LOGGING
+
+        self.assertEqual(logging_config['version'], 1)
+        self.assertFalse(logging_config['disable_existing_loggers'])
+        self.assertIn('console', logging_config['handlers'])
+        self.assertEqual(logging_config['handlers']['console']['class'], 'logging.StreamHandler')
+        self.assertEqual(logging_config['handlers']['console']['level'], settings.DJANGO_LOG_LEVEL)
+        self.assertEqual(logging_config['root']['handlers'], ['console'])
+        self.assertEqual(logging_config['root']['level'], settings.DJANGO_LOG_LEVEL)
+        self.assertIn('django', logging_config['loggers'])
+        self.assertIn('backend', logging_config['loggers'])


### PR DESCRIPTION
## What changed
- Added a centralized Django `LOGGING` configuration with a console handler and standardized formatter.
- Wired the log level to `DJANGO_LOG_LEVEL`, defaulting to `DEBUG` in development and `INFO` otherwise.
- Added a small settings test to verify the logging config stays normalized.

## Why
- The repo had scattered logger setup and no single Django logging policy.
- A shared config makes it easier to keep backend logs consistent across apps and environments.

## Validation
- `python3 -m py_compile backend/backend/settings.py backend/users/tests.py backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py`
- `git diff --check`
- `python3 backend/manage.py test users.tests -v 1`

Closes #395
