### PR TITLE
feat: warn on missing startup env vars

### DIFF
--- a/backend/backend/asgi.py
+++ b/backend/backend/asgi.py
@@ -1,5 +1,7 @@
 import os
 from django.core.asgi import get_asgi_application
+from .startup import warn_missing_startup_env_vars
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 application = get_asgi_application()
+warn_missing_startup_env_vars()

--- a/backend/backend/startup.py
+++ b/backend/backend/startup.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+
+_WARNED = False
+
+
+def warn_missing_startup_env_vars():
+    global _WARNED
+    if _WARNED:
+        return
+
+    required = ('GEMINI_API_KEY', 'GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET')
+    missing = [name for name in required if not str(getattr(settings, name, '') or '').strip()]
+    if not missing:
+        return
+
+    _WARNED = True
+    print(
+        f"\033[1m[LeadOrbit startup warning]\033[0m Missing environment variables: {', '.join(missing)}",
+        flush=True,
+    )

--- a/backend/backend/wsgi.py
+++ b/backend/backend/wsgi.py
@@ -1,5 +1,7 @@
 import os
 from django.core.wsgi import get_wsgi_application
+from .startup import warn_missing_startup_env_vars
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 application = get_wsgi_application()
+warn_missing_startup_env_vars()

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -104,3 +107,17 @@ class AuthMeViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertTrue(Organization.objects.filter(id=self.organization.id).exists())
         self.assertTrue(User.objects.filter(id=self.user.id).exists())
+
+
+@override_settings(GEMINI_API_KEY='', GOOGLE_CLIENT_ID='', GOOGLE_CLIENT_SECRET='')
+class StartupValidationTests(SimpleTestCase):
+    @patch('builtins.print')
+    def test_warn_missing_startup_env_vars_prints_bold_warning(self, mock_print):
+        from backend.startup import warn_missing_startup_env_vars
+
+        warn_missing_startup_env_vars()
+
+        mock_print.assert_called_once()
+        warning_message = mock_print.call_args.args[0]
+        self.assertIn('[LeadOrbit startup warning]', warning_message)
+        self.assertIn('Missing environment variables: GEMINI_API_KEY, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET', warning_message)


### PR DESCRIPTION
### What changed
- Added a small startup helper that warns when essential runtime env vars are missing.
- Hooked the check into both WSGI and ASGI startup paths.
- Added a test that verifies the warning is printed for missing Gemini/Google OAuth settings.

### Why
- The app could start successfully and only fail later when a feature needed an unset credential.
- A clear startup warning makes misconfiguration easier to catch before deployment.

### Validation
- `python3 -m py_compile backend/backend/startup.py backend/backend/wsgi.py backend/backend/asgi.py backend/users/tests.py`
- `git diff --check`
- `python3 backend/manage.py test users.tests.StartupValidationTests -v 2`

Closes #405
