### PR TITLE
docs: add backend coverage reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,17 @@ python manage.py test
 
 Ensure all tests pass successfully.
 
+To measure test coverage locally:
+
+```bash
+cd backend
+coverage run manage.py test
+coverage report
+coverage html
+```
+
+The generated HTML report will be available in `backend/htmlcov/`.
+
 ---
 
 ## Code Style Guidelines

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,18 @@
+[run]
+branch = True
+source =
+    backend
+    campaigns
+    leads
+    tenants
+    users
+
+[report]
+omit =
+    */migrations/*
+    */venv/*
+    */.venv/*
+    */__pycache__/*
+
+[html]
+directory = htmlcov

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ google-auth-oauthlib>=1.2,<2.0
 firebase-admin>=6.5,<7.0
 twilio>=9.0,<10.0
 gunicorn>=20.1,<21.0
+coverage>=7.6,<8.0


### PR DESCRIPTION
### What changed
- Added `coverage` to the project requirements.
- Added a backend `.coveragerc` that excludes migrations and virtual environments.
- Documented the local coverage workflow in `CONTRIBUTING.md`.

### Why
- Contributors need a simple, repeatable way to measure which backend areas are covered by tests.
- This makes it easier to spot missing coverage before opening a PR.

### Validation
- `git diff --check`

Closes #391
