### PR TITLE
feat: add celery beat health check

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -151,9 +151,28 @@ CELERY_TASK_ALWAYS_EAGER = os.getenv(
 ).lower() in ('true', '1', 'yes')
 CELERY_TASK_EAGER_PROPAGATES = True
 
+if DEBUG:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'leadorbit-local-cache',
+        }
+    }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': os.getenv('CACHE_URL', os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')),
+        }
+    }
+
 CELERY_BEAT_SCHEDULE = {
     'process-campaign-leads-every-minute': {
         'task': 'campaigns.tasks.process_active_leads',
+        'schedule': 60.0,
+    },
+    'celery-beat-heartbeat-every-minute': {
+        'task': 'campaigns.tasks.celery_heartbeat',
         'schedule': 60.0,
     },
     'poll-gmail-replies-every-5-minutes': {

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -17,6 +17,7 @@ from campaigns.views import (
     CampaignViewSet,
     SequenceStepViewSet,
     EmailTemplateViewSet,
+    CeleryBeatHealthView,
     WebhookView,
     DashboardAnalyticsView,
     AIGenerateView,
@@ -51,6 +52,7 @@ urlpatterns = [
     path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/v1/webhooks/email/', WebhookView.as_view(), name='email_webhook'),
     path('api/v1/analytics/dashboard/', DashboardAnalyticsView.as_view(), name='dashboard_analytics'),
+    path('api/v1/health/celery-beat/', CeleryBeatHealthView.as_view(), name='celery_beat_health'),
     path('api/v1/campaigns/ai-generate/', AIGenerateView.as_view(), name='ai_generate'),
     
     

--- a/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
+++ b/backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0009_campaign_cached_counters'),
+        ('campaigns', '0009_campaignlead_bounce_metadata'),
+    ]
+
+    operations = []

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -1,21 +1,25 @@
-import logging from datetime 
-import timedelta from celery 
-import shared_task from django.conf 
-import settings as django_settings from django.utils 
-import timezone from .ai 
-import _apply_merge_tags, personalize_email from .gmail_service
-import build_unsubscribe_url, check_for_replies, send_gmail from .sms_service 
-import send_sms, initiate_call from .models 
-import CampaignLead, SequenceStep from leads.models 
-import BlockedDomain, normalize_domain
-
-
+import logging
 import urllib.parse
+from datetime import timedelta
+
 from bs4 import BeautifulSoup
+from celery import shared_task
+from django.conf import settings as django_settings
+from django.core.cache import cache
 from django.core.signing import Signer
+from django.utils import timezone
+
+from .ai import _apply_merge_tags, personalize_email
+from .gmail_service import build_unsubscribe_url, check_for_replies, send_gmail
+from .models import CampaignLead, SequenceStep
+from .sms_service import send_sms, initiate_call
+from leads.models import BlockedDomain, normalize_domain
 
 
 logger = logging.getLogger(__name__)
+
+CELERY_BEAT_HEARTBEAT_KEY = 'celery_beat_heartbeat'
+CELERY_BEAT_HEARTBEAT_MAX_AGE_SECONDS = 180
 
 def _get_campaign_steps(campaign):
     """
@@ -115,6 +119,23 @@ def _maybe_mark_campaign_completed(campaign):
     campaign.status = 'COMPLETED'
     campaign.save(update_fields=['status'])
     logger.info(f"Campaign marked COMPLETED: {campaign.id}")
+
+
+@shared_task
+def celery_heartbeat():
+    """
+    Periodic heartbeat used by the health endpoint to confirm Celery Beat is alive.
+    """
+    now = timezone.now().timestamp()
+    cache.set(
+        CELERY_BEAT_HEARTBEAT_KEY,
+        now,
+        timeout=CELERY_BEAT_HEARTBEAT_MAX_AGE_SECONDS * 2,
+    )
+    return {
+        'heartbeat_key': CELERY_BEAT_HEARTBEAT_KEY,
+        'timestamp': now,
+    }
 
 
 def _advance_to_next_step(clead, completed_step, now=None):

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -13,11 +13,13 @@ from campaigns.ai import personalize_email
 from campaigns.tasks import (
     _execute_condition_event_step,
     _get_campaign_steps,
+    celery_heartbeat,
     poll_gmail_for_replies,
     process_active_leads,
     process_active_leads_once,
     send_email_step,
 )
+from django.core.cache import cache
 from campaigns.utils import generate_unsubscribe_token
 from leads.models import BlockedDomain, Lead
 from tenants.models import Organization
@@ -1303,6 +1305,39 @@ class CampaignWorkflowTests(APITestCase):
         self.client.force_authenticate(user=None)
         response = self.client.get('/api/v1/analytics/dashboard/')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_celery_beat_health_reports_503_until_heartbeat_updates(self):
+        cache.clear()
+        response = self.client.get('/api/v1/health/celery-beat/')
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertFalse(response.data['healthy'])
+        self.assertFalse(response.data['heartbeat_present'])
+
+    def test_celery_beat_health_reports_healthy_after_recent_heartbeat(self):
+        cache.clear()
+        celery_heartbeat()
+
+        response = self.client.get('/api/v1/health/celery-beat/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['healthy'])
+        self.assertTrue(response.data['heartbeat_present'])
+        self.assertLessEqual(response.data['heartbeat_age_seconds'], 180)
+
+    def test_celery_beat_health_marks_stale_heartbeat_unhealthy(self):
+        cache.set(
+            'celery_beat_heartbeat',
+            timezone.now().timestamp() - 240,
+            timeout=600,
+        )
+
+        response = self.client.get('/api/v1/health/celery-beat/')
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertFalse(response.data['healthy'])
+        self.assertTrue(response.data['heartbeat_present'])
+        self.assertGreater(response.data['heartbeat_age_seconds'], 180)
 
     def test_unsubscribe_get_shows_confirmation_without_updating_lead(self):
         lead = Lead.objects.create(

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -1,21 +1,25 @@
 import logging
-
-
 import urllib.parse
+from datetime import datetime, timezone as dt_timezone
+
+from django.core.cache import cache
 from django.core.signing import Signer, BadSignature
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
+from django.utils import timezone
 # ------------------------------------------
 
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from leads.models import Lead
 from users.permissions import IsOrgManager
 
 from .models import Campaign, CampaignLead, SequenceStep, EmailTemplate
 from .serializers import CampaignSerializer, SequenceStepSerializer, EmailTemplateSerializer
+from .tasks import CELERY_BEAT_HEARTBEAT_KEY, CELERY_BEAT_HEARTBEAT_MAX_AGE_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -711,6 +715,54 @@ class AIGenerateView(APIView):
             "Your Name"
         )
         return f"SUBJECT: {subject}\nBODY: {body}"
+
+
+class CeleryBeatHealthView(APIView):
+    """
+    Read-only health endpoint that reports whether Celery Beat is updating the
+    heartbeat cache key frequently enough.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        raw_heartbeat = cache.get(CELERY_BEAT_HEARTBEAT_KEY)
+        if raw_heartbeat is None:
+            return Response(
+                {
+                    'healthy': False,
+                    'heartbeat_present': False,
+                    'detail': 'Celery Beat heartbeat is missing.',
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        try:
+            heartbeat_ts = float(raw_heartbeat)
+        except (TypeError, ValueError):
+            return Response(
+                {
+                    'healthy': False,
+                    'heartbeat_present': True,
+                    'detail': 'Celery Beat heartbeat is malformed.',
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        now_ts = timezone.now().timestamp()
+        age_seconds = now_ts - heartbeat_ts
+        healthy = age_seconds <= CELERY_BEAT_HEARTBEAT_MAX_AGE_SECONDS
+        response_status = status.HTTP_200_OK if healthy else status.HTTP_503_SERVICE_UNAVAILABLE
+
+        return Response(
+            {
+                'healthy': healthy,
+                'heartbeat_present': True,
+                'heartbeat_age_seconds': round(age_seconds, 1),
+                'last_heartbeat': datetime.fromtimestamp(heartbeat_ts, tz=dt_timezone.utc).isoformat(),
+                'max_age_seconds': CELERY_BEAT_HEARTBEAT_MAX_AGE_SECONDS,
+            },
+            status=response_status,
+        )
     
 from django.http import HttpResponse
 from django.middleware.csrf import get_token


### PR DESCRIPTION
Adds a periodic Celery Beat heartbeat and a small authenticated health endpoint so the dashboard can detect when scheduled background processing stops updating.

What changed:
- added a `celery_heartbeat` task that writes a timestamp into cache every minute
- added `/api/v1/health/celery-beat/` to report whether the heartbeat is fresh enough
- configured cache backends so the heartbeat works locally and can use Redis in non-debug deployments
- added regression tests for healthy, stale, and missing heartbeat states
- added the campaigns migration merge file needed to keep the test database migratable on this baseline

Validation:
- `python3 -m py_compile backend/backend/settings.py backend/campaigns/tasks.py backend/campaigns/views.py backend/backend/urls.py backend/campaigns/tests.py backend/campaigns/migrations/0010_merge_0009_campaign_cached_counters_0009_campaignlead_bounce_metadata.py`
- `python3 backend/manage.py test campaigns.tests.CampaignWorkflowTests.test_celery_beat_health_reports_503_until_heartbeat_updates campaigns.tests.CampaignWorkflowTests.test_celery_beat_health_reports_healthy_after_recent_heartbeat campaigns.tests.CampaignWorkflowTests.test_celery_beat_health_marks_stale_heartbeat_unhealthy -v 2`
- `git diff --check`
