### PR TITLE
feat: add startup settings warnings

### DIFF
--- a/backend/backend/asgi.py
+++ b/backend/backend/asgi.py
@@ -3,3 +3,7 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 application = get_asgi_application()
+
+from .startup import warn_missing_critical_settings
+
+warn_missing_critical_settings()

--- a/backend/backend/startup.py
+++ b/backend/backend/startup.py
@@ -1,0 +1,34 @@
+"""Startup checks for critical deployment settings."""
+
+import sys
+
+from django.conf import settings
+
+CRITICAL_STARTUP_SETTINGS = (
+    'GEMINI_API_KEY',
+    'GOOGLE_CLIENT_ID',
+    'GOOGLE_CLIENT_SECRET',
+)
+
+
+def warn_missing_critical_settings(stream=None):
+    """
+    Print a bold-style warning for missing startup settings and return them.
+    """
+    missing = [
+        name
+        for name in CRITICAL_STARTUP_SETTINGS
+        if not str(getattr(settings, name, '') or '').strip()
+    ]
+
+    if not missing:
+        return []
+
+    output = stream or sys.stdout
+    print(
+        '*** WARNING: Missing LeadOrbit startup settings: '
+        f"{', '.join(missing)} ***",
+        file=output,
+        flush=True,
+    )
+    return missing

--- a/backend/backend/tests.py
+++ b/backend/backend/tests.py
@@ -1,0 +1,36 @@
+from io import StringIO
+
+from django.test import SimpleTestCase, override_settings
+
+from .startup import warn_missing_critical_settings
+
+
+class StartupSettingsValidationTests(SimpleTestCase):
+    @override_settings(
+        GEMINI_API_KEY='',
+        GOOGLE_CLIENT_ID='',
+        GOOGLE_CLIENT_SECRET='',
+    )
+    def test_warns_when_critical_settings_are_missing(self):
+        buffer = StringIO()
+
+        missing = warn_missing_critical_settings(stream=buffer)
+
+        self.assertEqual(
+            missing,
+            ['GEMINI_API_KEY', 'GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'],
+        )
+        self.assertIn('Missing LeadOrbit startup settings', buffer.getvalue())
+
+    @override_settings(
+        GEMINI_API_KEY='gemini-key',
+        GOOGLE_CLIENT_ID='client-id',
+        GOOGLE_CLIENT_SECRET='client-secret',
+    )
+    def test_returns_quietly_when_all_settings_exist(self):
+        buffer = StringIO()
+
+        missing = warn_missing_critical_settings(stream=buffer)
+
+        self.assertEqual(missing, [])
+        self.assertEqual(buffer.getvalue(), '')

--- a/backend/backend/wsgi.py
+++ b/backend/backend/wsgi.py
@@ -3,3 +3,7 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 application = get_wsgi_application()
+
+from .startup import warn_missing_critical_settings
+
+warn_missing_critical_settings()


### PR DESCRIPTION
Adds startup-time warnings for missing critical environment settings so misconfigured deployments fail visibly instead of breaking later in feature code.

What changed:
- added a small startup helper that prints a bold-style warning listing missing critical settings
- invoked the helper from both `wsgi.py` and `asgi.py` after Django setup
- added unit tests for both the warning and quiet paths

Validation:
- `python3 -m py_compile backend/backend/startup.py backend/backend/wsgi.py backend/backend/asgi.py backend/backend/tests.py`
- `python3 backend/manage.py test backend.tests.StartupSettingsValidationTests -v 2`
- `git diff --check`
