### PR TITLE
feat: standardize django logging

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -130,6 +130,9 @@ USE_TZ = True
 STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+LOG_DIR = BASE_DIR / 'logs'
+os.makedirs(LOG_DIR, exist_ok=True)
+
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
@@ -173,6 +176,81 @@ SIMPLE_JWT = {
 
 # Allow all origins in development
 CORS_ALLOW_ALL_ORIGINS = True
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '[{levelname}] {asctime} {name}: {message}',
+            'style': '{',
+        },
+        'simple': {
+            'format': '{levelname}: {message}',
+            'style': '{',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://sys.stdout',
+            'formatter': 'simple',
+        },
+        'file': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': str(LOG_DIR / 'leadorbit.log'),
+            'maxBytes': 5 * 1024 * 1024,
+            'backupCount': 3,
+            'formatter': 'verbose',
+        },
+    },
+    'root': {
+        'handlers': ['console', 'file'],
+        'level': 'INFO',
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'django.db.backends': {
+            'handlers': ['console', 'file'],
+            'level': 'DEBUG' if DEBUG else 'INFO',
+            'propagate': False,
+        },
+        'celery': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'celery.app.trace': {
+            'handlers': ['console', 'file'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'campaigns': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'leads': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'tenants': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'users': {
+            'handlers': ['console', 'file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    },
+}
 
 # Gemini API Key
 GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', _read_local_env_value('GEMINI_API_KEY', ''))

--- a/backend/backend/tests.py
+++ b/backend/backend/tests.py
@@ -1,0 +1,13 @@
+from django.test import SimpleTestCase
+from django.conf import settings as django_settings
+
+
+class LoggingSettingsTests(SimpleTestCase):
+    def test_logging_config_includes_console_file_and_backend_loggers(self):
+        logging_config = django_settings.LOGGING
+
+        self.assertIn('console', logging_config['handlers'])
+        self.assertIn('file', logging_config['handlers'])
+        self.assertIn('django.db.backends', logging_config['loggers'])
+        self.assertIn('celery.app.trace', logging_config['loggers'])
+        self.assertEqual(logging_config['root']['handlers'], ['console', 'file'])


### PR DESCRIPTION
Standardizes Django logging with a dictConfig setup so LeadOrbit emits predictable console and file logs for app code, database queries, and Celery task failures.

What changed:
- added a shared `LOGGING` config in `settings.py`
- configured console and rotating file handlers with consistent formatters
- routed `django.db.backends`, `celery.app.trace`, and project loggers through the same structured handlers
- added a lightweight settings test to verify the expected logging structure

Validation:
- `python3 -m py_compile backend/backend/settings.py backend/backend/tests.py`
- `python3 backend/manage.py test backend.tests.LoggingSettingsTests -v 2`
- `git diff --check`
