### PR TITLE
test: add backend coverage reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+If you are working on backend tests and coverage locally, install the coverage helper too:
+
+```bash
+pip install coverage
+```
+
 ### 5. Configure Environment Variables
 
 Create a `backend/.env` file and add the required environment variables as described in the README.
@@ -111,6 +117,16 @@ python manage.py test
 ```
 
 Ensure all tests pass successfully.
+
+To generate coverage data and a browsable HTML report:
+
+```bash
+cd backend
+coverage run manage.py test
+coverage html
+```
+
+The backend coverage configuration lives in `backend/.coveragerc` and excludes virtual environments and migrations.
 
 ---
 

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+source = .
+omit =
+    */venv/*
+    */.venv/*
+    */migrations/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if TYPE_CHECKING:
+    if __name__ == .__main__.:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ google-auth-oauthlib>=1.2,<2.0
 firebase-admin>=6.5,<7.0
 twilio>=9.0,<10.0
 gunicorn>=20.1,<21.0
+coverage>=7.6,<8.0


### PR DESCRIPTION
## What changed
- Added `coverage` to the shared dependency list so contributors can run coverage locally.
- Added `backend/.coveragerc` to exclude virtual environments and migrations from coverage reporting.
- Documented the `coverage run manage.py test` and `coverage html` workflow in `CONTRIBUTING.md`.

## Why
- Issue #391 asks for a beginner-friendly way to measure backend test coverage and generate reports.
- The setup makes it easier to spot missing tests without changing application behavior.

## Validation
- `git diff --check`

Closes #391
