### PR TITLE
fix: add max validation for SMTP and IMAP ports

### DIFF
--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -178,7 +178,7 @@
                                     </div>
                                     <div class="col-md-3">
                                         <label class="form-label small text-muted fw-semibold">SMTP Port</label>
-                                        <input type="number" class="form-control" id="custom-smtp-port" value="587" min="1">
+                                        <input type="number" class="form-control" id="custom-smtp-port" value="587" min="1" max="65535">
                                     </div>
                                     <div class="col-md-3">
                                         <label class="form-label small text-muted fw-semibold">SMTP Username</label>
@@ -206,7 +206,7 @@
                                     </div>
                                     <div class="col-md-3">
                                         <label class="form-label small text-muted fw-semibold">IMAP Port</label>
-                                        <input type="number" class="form-control" id="custom-imap-port" value="993" min="1">
+                                        <input type="number" class="form-control" id="custom-imap-port" value="993" min="1" max="65535">
                                     </div>
                                     <div class="col-md-3">
                                         <label class="form-label small text-muted fw-semibold">IMAP Username</label>


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #438

---

## 📝 Summary of Changes

- Added `max="65535"` validation to the Custom SMTP Port input.
- Added `max="65535"` validation to the Custom IMAP Port input.
- Prevents users from entering port numbers outside the valid TCP/UDP port range.
- Existing functionality and default values remain unchanged.

---

## 🏷️ Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

**Steps to test:**

1. Open the **Settings** page.
2. Go to the **Custom SMTP/IMAP Configuration** section.
3. Verify that both SMTP Port and IMAP Port inputs now have a maximum value of **65535**.
4. Confirm the default values (587 and 993) are unchanged.
5. Attempt to enter a value greater than **65535** and verify that the browser prevents invalid input.

---

## 📸 Screenshots (if applicable)

N/A

---

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (not applicable)
* [x] Related issue linked
* [x] Changes tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation limits to custom SMTP and IMAP port fields, preventing users from entering out-of-range port numbers.
  * Port inputs now accept only values from 1 to 65535, improving form consistency and reducing configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->