### PR TITLE
fix: prevent duplicate tags on leads

### DIFF
--- a/backend/leads/migrations/0006_leadtag_unique_constraint.py
+++ b/backend/leads/migrations/0006_leadtag_unique_constraint.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('leads', '0005_merge_0004_leadimportjob_0004_tag_color'),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name='leadtag',
+            constraint=models.UniqueConstraint(fields=('lead', 'tag'), name='unique_lead_tag'),
+        ),
+    ]

--- a/backend/leads/models.py
+++ b/backend/leads/models.py
@@ -76,6 +76,9 @@ class LeadTag(TenantModel):
 
     class Meta:
         unique_together = ('lead', 'tag')
+        constraints = [
+            models.UniqueConstraint(fields=['lead', 'tag'], name='unique_lead_tag'),
+        ]
 
 class BlockedDomain(TenantModel):
     domain = models.CharField(max_length=255)

--- a/backend/leads/serializers.py
+++ b/backend/leads/serializers.py
@@ -34,18 +34,21 @@ class LeadSerializer(serializers.ModelSerializer):
         return TagSerializer(tags, many=True).data
 
     def _set_tags(self, lead, tag_ids):
-        """Replace the lead's tags with the given list of Tag UUIDs."""
         org = lead.organization
         tags = Tag.objects.filter(id__in=tag_ids, organization=org)
-        # Remove tags not in the new set
         LeadTag.objects.filter(lead=lead).exclude(tag__in=tags).delete()
-        # Add new tags that are not already assigned
         existing_tag_ids = set(
             LeadTag.objects.filter(lead=lead).values_list('tag_id', flat=True)
         )
-        for tag in tags:
-            if tag.id not in existing_tag_ids:
-                LeadTag.objects.create(lead=lead, tag=tag, organization=org)
+        new_tags = [tag for tag in tags if tag.id not in existing_tag_ids]
+        duplicate_tags = [tag for tag in tags if tag.id in existing_tag_ids]
+        if duplicate_tags:
+            duplicate_names = [tag.name for tag in duplicate_tags]
+            raise serializers.ValidationError(
+                {"tag_ids": f"Tags already assigned to this lead: {', '.join(duplicate_names)}"}
+            )
+        for tag in new_tags:
+            LeadTag.objects.create(lead=lead, tag=tag, organization=org)
 
     def create(self, validated_data):
         tag_ids = validated_data.pop('tag_ids', None)

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -144,9 +144,18 @@ class LeadViewSet(viewsets.ModelViewSet):
         existing_tag_ids = set(
             LeadTag.objects.filter(lead=lead).values_list('tag_id', flat=True)
         )
+        duplicate_ids = [str(tag.id) for tag in tags if tag.id in existing_tag_ids]
+        if duplicate_ids:
+            duplicate_names = list(
+                Tag.objects.filter(id__in=duplicate_ids, organization=org).values_list('name', flat=True)
+            )
+            return Response(
+                {"error": "Tag already assigned to this lead", "duplicates": duplicate_names},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         for tag in tags:
-            if tag.id not in existing_tag_ids:
-                LeadTag.objects.create(lead=lead, tag=tag, organization=org)
+            LeadTag.objects.create(lead=lead, tag=tag, organization=org)
 
         # Return the updated tag list
         updated_tags = Tag.objects.filter(tagged_leads__lead=lead)

--- a/frontend/leads.html
+++ b/frontend/leads.html
@@ -71,6 +71,12 @@
             flex-shrink: 0;
         }
 
+        .tag-filter-chip.disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
         .tag-filter-chip.selected {
             outline: 2px solid var(--focus-ring);
             outline-offset: 1px;
@@ -648,7 +654,10 @@
             }
         }
 
-        function renderTagFilterChips() {
+        let assignedTagIds = new Set();
+
+        function renderTagFilterChips(assignedIds) {
+            if (assignedIds) assignedTagIds = new Set(assignedIds);
             const container = document.getElementById('tag-filter-chips');
             if (!allTags.length) {
                 container.innerHTML = '<span class="text-muted small">No tags yet. Create tags in Settings.</span>';
@@ -658,20 +667,21 @@
                 const bg = tag.color || '#6366f1';
                 const fg = contrastColor(bg);
                 const isSelected = selectedTagIds.has(tag.id);
+                const isAssigned = assignedTagIds.has(tag.id);
                 return `
                 <button
-                    class="tag-filter-chip${isSelected ? ' selected' : ''}"
+                    class="tag-filter-chip${isSelected ? ' selected' : ''}${isAssigned ? ' disabled' : ''}"
                     data-tag-id="${tag.id}"
                     style="background:${bg};color:${fg};border-color:${isSelected ? 'var(--focus-ring)' : bg};"
                     type="button"
                     aria-pressed="${isSelected}"
-                    title="Filter by ${escapeHtml(tag.name)}">
+                    ${isAssigned ? 'disabled title="Already assigned to this lead"' : `title="Filter by ${escapeHtml(tag.name)}"`}>
                     <span class="tag-dot" style="background:${fg};opacity:0.6;"></span>
                     ${escapeHtml(tag.name)}
                 </button>`;
-            }).join('');
+            });
 
-            container.querySelectorAll('.tag-filter-chip').forEach(chip => {
+            container.querySelectorAll('.tag-filter-chip:not(.disabled)').forEach(chip => {
                 chip.addEventListener('click', () => {
                     const id = chip.dataset.tagId;
                     if (selectedTagIds.has(id)) {


### PR DESCRIPTION
Closes #436

### What does this PR do?

Prevents the same tag from being assigned to a lead multiple times.

Changes:
- Added unique constraint on LeadTag (lead, tag) in the model
- Added duplicate check before tag creation in the view
- Returns 400 Bad Request with clear message when duplicate is attempted
- Updated frontend dropdown to disable already-assigned tags

### How did you verify your code works?

Logic follows the implementation guide in #436. The constraint enforces uniqueness at the DB level, and the view provides a graceful error response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tag assignment now prevents duplicate tags from being added to the same lead and returns a clear validation error when duplicates are selected.
  * Existing tag chips already assigned to a lead are now shown as disabled, with a tooltip explaining why they can’t be selected again.

* **Data Integrity**
  * Added stronger safeguards to keep each lead-and-tag combination unique.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->