### PR TITLE
fix: trim whitespace from login and registration inputs

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -158,8 +158,9 @@
             if (form) {
                 form.addEventListener('submit', async (e) => {
                     e.preventDefault();
-                    const email = document.getElementById('floatingInput').value;
+                    const email = document.getElementById('floatingInput').value.trim();
                     const password = document.getElementById('floatingPassword').value;
+
                     try {
                         const btn = form.querySelector('button[type="submit"]');
                         btn.disabled = true;

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -176,10 +176,10 @@
                 form.addEventListener('submit', async (e) => {
                     e.preventDefault();
 
-                    const first_name = document.getElementById('firstName').value;
-                    const last_name = document.getElementById('lastName').value;
-                    const email = document.getElementById('emailAddress').value;
-                    const password = document.getElementById('password').value;
+                    const first_name = document.getElementById('firstName').value.trim();
+                    const last_name = document.getElementById('lastName').value.trim();
+                    const email = document.getElementById('emailAddress').value.trim();
+                    const password = document.getElementById('password').value.trim();
 
                     const organization_name = first_name + "'s Organization";
 

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -179,7 +179,7 @@
                     const first_name = document.getElementById('firstName').value.trim();
                     const last_name = document.getElementById('lastName').value.trim();
                     const email = document.getElementById('emailAddress').value.trim();
-                    const password = document.getElementById('password').value.trim();
+                    const password = document.getElementById('password').value;
 
                     const organization_name = first_name + "'s Organization";
 


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #474

---

## 📝 Summary of Changes


Trim leading and trailing whitespace from login email.
Trim leading and trailing whitespace from registration name and email fields.
Preserve the password exactly as entered.

## 🏷️ Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

**Steps to test:**
1. Tested login with leading/trailing spaces in email and password.
2. Tested registration with leading/trailing spaces in input fields.
3. Verified that whitespace is removed before submitting the form.

---

## 📸 Screenshots (if applicable)

N/A

---

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [x] Related issue linked
* [x] Changes tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in by trimming leading/trailing whitespace from the email before authentication.
  * Improved registration by trimming leading/trailing whitespace from first name, last name, and email before creating the account and submitting registration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->