### PR TITLE
feat: add scroll-to-top button for long list pages

### DIFF
--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -2756,6 +2756,16 @@ document.getElementById('setting-daily-limit').value =
         }
     }
 </script>
+   
+    <button
+    id="scrollTopBtn"
+    class="btn btn-primary btn-scroll-top"
+    type="button"
+    aria-label="Scroll to top"
+>
+    <i class="bi bi-arrow-up"></i>
+</button>
+
 </body>
 
 </html>

--- a/frontend/leads.html
+++ b/frontend/leads.html
@@ -884,6 +884,16 @@
         });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <button
+      id="scrollTopBtn"
+      class="btn btn-primary btn-scroll-top"
+      type="button"
+      aria-label="Scroll to top"
+>
+      <i class="bi bi-arrow-up"></i>
+    </button>
+
 </body>
 
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -369,7 +369,8 @@ async function initAppShell() {
     initThemeToggle();
     initPasswordVisibilityToggle();
     injectSessionTimeoutModal();
-
+    initScrollToTopButton();
+    
     document.addEventListener('click', (event) => {
     if (event.target.id === 'sessionLogoutBtn') {
         clearSessionTimers();
@@ -605,4 +606,33 @@ if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initKeyboardShortcuts);
 } else {
     initKeyboardShortcuts();
+}
+
+// ==========================================
+// SCROLL TO TOP BUTTON
+// ==========================================
+
+function initScrollToTopButton() {
+    const button = document.getElementById('scrollTopBtn');
+
+    if (!button) return;
+
+    const toggleButton = () => {
+        if (window.scrollY > 300) {
+            button.classList.add('show');
+        } else {
+            button.classList.remove('show');
+        }
+    };
+
+    window.addEventListener('scroll', toggleButton);
+
+    button.addEventListener('click', () => {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
+    });
+
+    toggleButton();
 }

--- a/frontend/theme.css
+++ b/frontend/theme.css
@@ -1304,3 +1304,31 @@ body.auth-page {
 .password-toggle-btn i {
   pointer-events: none;
 }
+
+/* ==========================================
+   Scroll To Top Button
+========================================== */
+
+.btn-scroll-top {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 999;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(15px);
+    transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+}
+
+.btn-scroll-top.show {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}


### PR DESCRIPTION
## Description

This PR introduces a reusable **Scroll-to-Top** button for long list pages to improve navigation and user experience.

### Changes Made

- Added a floating scroll-to-top button.
- Implemented smooth scrolling back to the top.
- Display the button after the user scrolls beyond the configured threshold.
- Added reusable styling in `frontend/theme.css`.
- Integrated the feature into:
  - `frontend/leads.html`
  - `frontend/campaign-builder.html`

### Testing

- Verified that the button is injected correctly on both pages.
- Verified smooth scrolling behavior.

Fixes #473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating “scroll to top” button on key pages.
  * The button appears after scrolling and smoothly returns users to the top of the page.
* **Style**
  * Added visual styling and transition effects so the button matches the app’s look and feel.
* **Bug Fixes**
  * Improved page navigation convenience for long pages by making it easier to jump back to the top.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->