### PR TITLE
Add campaign lead status breakdown

### DIFF
--- a/backend/campaigns/serializers.py
+++ b/backend/campaigns/serializers.py
@@ -27,6 +27,7 @@ class CampaignSerializer(serializers.ModelSerializer):
     steps = serializers.SerializerMethodField()
     enrolled_count = serializers.IntegerField(source='leads_count', read_only=True)
     enrolled_lead_ids = serializers.SerializerMethodField()
+    status_breakdown = serializers.SerializerMethodField()
     connected_account = serializers.SerializerMethodField()
     connected_account_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
 
@@ -40,6 +41,7 @@ class CampaignSerializer(serializers.ModelSerializer):
             'steps',
             'enrolled_count',
             'enrolled_lead_ids',
+            'status_breakdown',
             'sent_count',
             'open_count',
             'reply_count',
@@ -55,6 +57,13 @@ class CampaignSerializer(serializers.ModelSerializer):
 
     def get_enrolled_lead_ids(self, obj):
         return [str(lead_id) for lead_id in obj.enrolled_leads.values_list('lead_id', flat=True)]
+
+    def get_status_breakdown(self, obj):
+        counts = {status: 0 for status, _ in CampaignLead.STATUS_CHOICES}
+        for lead_status in obj.enrolled_leads.values_list('status', flat=True):
+            if lead_status in counts:
+                counts[lead_status] += 1
+        return counts
 
     def get_connected_account(self, obj):
         if not obj.connected_account:

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1442,6 +1442,41 @@ class CampaignWorkflowTests(APITestCase):
         campaign.refresh_from_db()
         self.assertEqual(campaign.status, 'ACTIVE')
 
+
+    def test_campaign_detail_includes_status_breakdown(self):
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Status overview',
+            status='ACTIVE',
+        )
+        replied_lead = Lead.objects.create(
+            organization=self.organization,
+            email='replied-status@acme.test',
+        )
+        bounced_lead = Lead.objects.create(
+            organization=self.organization,
+            email='bounced-status@acme.test',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=replied_lead,
+            status='REPLIED',
+        )
+        CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=bounced_lead,
+            status='BOUNCED',
+        )
+
+        response = self.client.get(f'/api/v1/campaigns/{campaign.id}/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['status_breakdown']['REPLIED'], 1)
+        self.assertEqual(response.data['status_breakdown']['BOUNCED'], 1)
+        self.assertEqual(response.data['status_breakdown']['ENROLLED'], 0)
+
     def test_condition_time_is_mapped_to_delay_minutes(self):
         payload = {
             'name': 'Condition delay mapping',

--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -106,6 +106,14 @@
             background: #22c55e;
         }
 
+
+        .status-dot {
+            width: 0.7rem;
+            height: 0.7rem;
+            border-radius: 999px;
+            display: inline-block;
+            flex-shrink: 0;
+        }
         .status-toggle::after {
             content: '';
             width: 18px;
@@ -1246,6 +1254,7 @@
         let aiComposerStep = null;
         let aiConversation = [];
         let aiLatestDraft = null;
+        let campaignStatusBreakdown = null;
 
         // Steps are stored as an array of objects
         let steps = [
@@ -1642,6 +1651,77 @@ ${rows || `
             `;
         }
 
+        function getCampaignStatusBreakdown() {
+            const statusMeta = [
+                { key: 'ENROLLED', label: 'Enrolled', className: 'bg-primary' },
+                { key: 'ACTIVE', label: 'Active', className: 'bg-success' },
+                { key: 'PAUSED', label: 'Paused', className: 'bg-warning' },
+                { key: 'REPLIED', label: 'Replied', className: 'bg-info' },
+                { key: 'BOUNCED', label: 'Bounced', className: 'bg-danger' },
+                { key: 'SKIPPED', label: 'Skipped', className: 'bg-dark' },
+                { key: 'FINISHED', label: 'Finished', className: 'bg-secondary' },
+            ];
+
+            if (campaignStatusBreakdown && typeof campaignStatusBreakdown === 'object') {
+                return statusMeta
+                    .map(item => ({ ...item, value: Number(campaignStatusBreakdown[item.key]) || 0 }))
+                    .filter(item => item.value > 0);
+            }
+
+            const totalLeads = selectedLeadIds.size || availableLeads.length || 0;
+            return totalLeads > 0
+                ? [{ key: 'ENROLLED', label: 'Enrolled', value: totalLeads, className: 'bg-primary' }]
+                : [];
+        }
+        function renderCampaignStatusBreakdown() {
+            const segments = getCampaignStatusBreakdown();
+            const totalLeads = segments.reduce((sum, segment) => sum + segment.value, 0);
+
+            if (!totalLeads) {
+                return `
+                    <div class="mt-4 p-3 rounded-3 panel-muted-box">
+                        <div class="d-flex align-items-center gap-2 mb-1">
+                            <i class="bi bi-bar-chart-line text-primary"></i>
+                            <h6 class="mb-0 fw-bold">Lead status breakdown</h6>
+                        </div>
+                        <p class="text-muted small mb-0">Select leads to preview enrolled, active, replied, bounced, paused, and finished proportions.</p>
+                    </div>
+                `;
+            }
+
+            const progressSegments = segments.map(segment => {
+                const width = Math.max(6, Math.round((segment.value / totalLeads) * 100));
+                return `<div class="progress-bar ${segment.className}" role="progressbar" style="width: ${width}%" aria-valuenow="${segment.value}" aria-valuemin="0" aria-valuemax="${totalLeads}">${segment.value}</div>`;
+            }).join('');
+
+            const legend = segments.map(segment => {
+                const percent = Math.round((segment.value / totalLeads) * 100);
+                return `
+                    <div class="d-flex align-items-center justify-content-between gap-3 small">
+                        <span class="d-inline-flex align-items-center gap-2"><span class="status-dot ${segment.className}"></span>${segment.label}</span>
+                        <span class="fw-semibold">${segment.value} (${percent}%)</span>
+                    </div>
+                `;
+            }).join('');
+
+            return `
+                <div class="mt-4 p-3 rounded-3 panel-muted-box">
+                    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+                        <div>
+                            <h6 class="mb-1 fw-bold">Lead status breakdown</h6>
+                            <div class="text-muted small">Visual progression for ${totalLeads} enrolled lead${totalLeads === 1 ? '' : 's'}.</div>
+                        </div>
+                        <span class="badge text-bg-light border">${segments.length} states</span>
+                    </div>
+                    <div class="progress mb-3" style="height: 26px; border-radius: 999px; overflow: hidden;">
+                        ${progressSegments}
+                    </div>
+                    <div class="d-grid gap-2">
+                        ${legend}
+                    </div>
+                </div>
+            `;
+        }
         function renderLaunchTab() {
             const canvas = document.getElementById('canvas');
             const statusText = document.getElementById('status-toggle').classList.contains('on') ? 'ACTIVE' : 'DRAFT';
@@ -1669,6 +1749,7 @@ ${rows || `
                             </div>
                         </div>
                     </div>
+                    ${renderCampaignStatusBreakdown()}
                     <div class="alert alert-info mt-4 mb-0">
                         Current status toggle: <b>${statusText}</b>. Launch will activate the campaign and trigger processing.
                     </div>
@@ -1725,6 +1806,7 @@ ${rows || `
 
             const data = await res.json();
             campaignId = data.id;
+            if (data.status_breakdown) campaignStatusBreakdown = data.status_breakdown;
             return data;
         }
 
@@ -1739,7 +1821,9 @@ ${rows || `
                 const err = await res.json().catch(() => ({}));
                 throw new Error(err.error || err.detail || 'Failed to enroll selected leads.');
             }
-            return res.json();
+            const data = await res.json();
+            if (data.status_breakdown) campaignStatusBreakdown = data.status_breakdown;
+            return data;
         }
 
         async function launchCampaign() {
@@ -2673,6 +2757,7 @@ ${rows || `
                     if (res.ok) {
                         const data = await res.json();
                         campaignId = data.id;
+                        campaignStatusBreakdown = data.status_breakdown || null;
                         document.getElementById('campaign-name').value = data.name;
                         if (data.status === 'ACTIVE') {
                             document.getElementById('status-toggle').classList.add('on');


### PR DESCRIPTION
## Summary
- Adds status_breakdown to campaign API responses using real CampaignLead statuses
- Renders a segmented lead status progress bar on the campaign launch review
- Adds API coverage for returned status counts

Closes #437

## Tests
- python AST syntax check for modified backend files
- Added targeted Django test: CampaignWorkflowTests.test_campaign_detail_includes_status_breakdown
- Could not run Django test locally because full dependency install failed with local disk-space limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a lead status breakdown to campaign details and launch views, showing how leads are distributed across statuses.
  * Campaign screens now display status indicators and update the breakdown after saving or enrolling leads.

* **Tests**
  * Added coverage to verify campaign details include the new status breakdown data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->