### PR TITLE
Feature/api rate limiting

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -142,7 +142,13 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
-    )
+    ),
+    'DEFAULT_THROTTLE_RATES': {
+        'login': '10/min',
+        'signup': '5/min',
+        'campaign_launch': '20/min',
+        'ai_draft': '15/min',
+    },
 }
 
 # Celery Configuration

--- a/backend/backend/throttles.py
+++ b/backend/backend/throttles.py
@@ -9,13 +9,33 @@ from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 
 class LoginRateThrottle(AnonRateThrottle):
-    """Throttles login attempts by client IP (user isn't authenticated yet)."""
+    """
+    Throttles login attempts by client IP, always — even if a stale or
+    unrelated Bearer token is attached to the request. Login should stay
+    IP-limited regardless of auth state, since the whole point is to
+    protect the endpoint itself against brute-force attempts.
+    """
     scope = 'login'
+
+    def get_cache_key(self, request, view):
+        return self.cache_format % {
+            'scope': self.scope,
+            'ident': self.get_ident(request),
+        }
 
 
 class SignupRateThrottle(AnonRateThrottle):
-    """Throttles account/organization signups by client IP."""
+    """
+    Throttles account/organization signups by client IP, always — same
+    reasoning as LoginRateThrottle above.
+    """
     scope = 'signup'
+
+    def get_cache_key(self, request, view):
+        return self.cache_format % {
+            'scope': self.scope,
+            'ident': self.get_ident(request),
+        }
 
 
 class CampaignLaunchThrottle(UserRateThrottle):

--- a/backend/backend/throttles.py
+++ b/backend/backend/throttles.py
@@ -1,0 +1,28 @@
+"""
+Custom DRF throttle classes for sensitive endpoints.
+
+Each class maps to a named "scope" whose rate is configured centrally in
+settings.py under REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"], so limits can
+be tuned without touching view code.
+"""
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+
+class LoginRateThrottle(AnonRateThrottle):
+    """Throttles login attempts by client IP (user isn't authenticated yet)."""
+    scope = 'login'
+
+
+class SignupRateThrottle(AnonRateThrottle):
+    """Throttles account/organization signups by client IP."""
+    scope = 'signup'
+
+
+class CampaignLaunchThrottle(UserRateThrottle):
+    """Throttles campaign launches per authenticated user."""
+    scope = 'campaign_launch'
+
+
+class AIDraftThrottle(UserRateThrottle):
+    """Throttles AI draft generation per authenticated user to protect AI spend/quota."""
+    scope = 'ai_draft'

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -5,9 +5,11 @@ from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.views import TokenObtainPairView as BaseTokenObtainPairView
 from users.jwt import CustomTokenObtainSerializer
+from backend.throttles import LoginRateThrottle
 
 class CustomTokenObtainPairView(BaseTokenObtainPairView):
     serializer_class = CustomTokenObtainSerializer
+    throttle_classes = [LoginRateThrottle]
 
 from users.views import AuthViewSet
 from leads.views import BlockedDomainViewSet, LeadImportJobViewSet, LeadViewSet, TagViewSet

--- a/backend/campaigns/test_throttling.py
+++ b/backend/campaigns/test_throttling.py
@@ -1,0 +1,111 @@
+from django.core.cache import cache
+from rest_framework.test import APITestCase
+from rest_framework import status
+from tenants.security import RateLimitMiddleware
+
+
+class AuthenticatedThrottleTestCase(APITestCase):
+    """
+    Shared setup: registers a fresh user + organization via the real API
+    (not direct model creation) and authenticates the test client, so
+    these tests stay valid even if model fields change later.
+    """
+
+    def setUp(self):
+        cache.clear()
+        RateLimitMiddleware._requests.clear()
+        self.addCleanup(cache.clear)
+        self.addCleanup(RateLimitMiddleware._requests.clear)
+        register_response = self.client.post(
+            '/api/v1/auth/register/',
+            {
+                'email': 'campaign_throttle_user@example.com',
+                'password': 'StrongPass123!',
+                'organization_name': 'Campaign Throttle Org',
+            },
+            format='json',
+        )
+        self.assertEqual(
+            register_response.status_code,
+            status.HTTP_201_CREATED,
+            msg=f'Setup registration failed: {register_response.content}',
+        )
+        access_token = register_response.data['access']
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access_token}')
+
+
+class CampaignLaunchThrottleTests(AuthenticatedThrottleTestCase):
+    """
+    Covers issue #18: campaign launch endpoint must throttle per
+    authenticated user, independent of business-logic outcomes
+    (e.g. "no leads enrolled" 400 responses still count toward the limit).
+    """
+
+    def setUp(self):
+        super().setUp()
+        create_response = self.client.post(
+            '/api/v1/campaigns/',
+            {'name': 'Throttle Test Campaign'},
+            format='json',
+        )
+        self.assertEqual(
+            create_response.status_code,
+            status.HTTP_201_CREATED,
+            msg=f'Setup campaign creation failed: {create_response.content}',
+        )
+        self.campaign_id = create_response.data['id']
+
+    def test_launch_allowed_within_limit(self):
+        response = self.client.post(f'/api/v1/campaigns/{self.campaign_id}/launch/')
+        self.assertNotEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_launch_blocked_after_limit(self):
+        """
+        Campaign launch scope is configured at 20/min. The 21st request
+        must be throttled even though earlier requests may return 400
+        (no leads enrolled) rather than 200.
+        """
+        last_response = None
+        for _ in range(21):
+            last_response = self.client.post(f'/api/v1/campaigns/{self.campaign_id}/launch/')
+        self.assertEqual(last_response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_other_campaign_actions_not_throttled_by_launch_scope(self):
+        """
+        Exhausting the launch limit must not affect unrelated actions
+        (enroll, pause, metrics) on the same viewset.
+        """
+        for _ in range(21):
+            self.client.post(f'/api/v1/campaigns/{self.campaign_id}/launch/')
+        metrics_response = self.client.get(f'/api/v1/campaigns/{self.campaign_id}/metrics/')
+        self.assertNotEqual(metrics_response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+
+class AIDraftThrottleTests(AuthenticatedThrottleTestCase):
+    """
+    Covers issue #18: AI draft generation endpoint must throttle per
+    authenticated user to protect AI provider spend/quota, including
+    when falling back to the local deterministic draft (no API key set).
+    """
+
+    def test_ai_generate_allowed_within_limit(self):
+        response = self.client.post(
+            '/api/v1/campaigns/ai-generate/',
+            {'prompt': 'Write a short intro email'},
+            format='json',
+        )
+        self.assertNotEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_ai_generate_blocked_after_limit(self):
+        """
+        AI draft scope is configured at 15/min. The 16th request must
+        be throttled.
+        """
+        last_response = None
+        for _ in range(16):
+            last_response = self.client.post(
+                '/api/v1/campaigns/ai-generate/',
+                {'prompt': 'Write a short intro email'},
+                format='json',
+            )
+        self.assertEqual(last_response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -16,6 +16,7 @@ from users.permissions import IsOrgManager
 
 from .models import Campaign, CampaignLead, SequenceStep, EmailTemplate
 from .serializers import CampaignSerializer, SequenceStepSerializer, EmailTemplateSerializer
+from backend.throttles import CampaignLaunchThrottle
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,11 @@ class CampaignViewSet(viewsets.ModelViewSet):
         if self.action in self.manager_actions:
             permissions.append(IsOrgManager())
         return permissions
+
+    def get_throttles(self):
+        if self.action == 'launch':
+            return [CampaignLaunchThrottle()]
+        return super().get_throttles()
 
     def get_queryset(self):
         return (

--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -16,7 +16,7 @@ from users.permissions import IsOrgManager
 
 from .models import Campaign, CampaignLead, SequenceStep, EmailTemplate
 from .serializers import CampaignSerializer, SequenceStepSerializer, EmailTemplateSerializer
-from backend.throttles import CampaignLaunchThrottle
+from backend.throttles import CampaignLaunchThrottle, AIDraftThrottle
 
 logger = logging.getLogger(__name__)
 
@@ -642,6 +642,7 @@ class AIGenerateView(APIView):
     Generate email content using the configured LLM provider for the campaign builder.
     """
     permission_classes = [IsAuthenticated]
+    throttle_classes = [AIDraftThrottle]
 
     def post(self, request, *args, **kwargs):
         prompt = (request.data.get('prompt') or '').strip()

--- a/backend/users/test_throttling.py
+++ b/backend/users/test_throttling.py
@@ -1,0 +1,102 @@
+from tenants.security import RateLimitMiddleware
+from django.core.cache import cache
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+
+class SignupThrottleTests(APITestCase):
+    """
+    Covers issue #18: signup endpoint must throttle unauthenticated
+    requests by IP, separately from other throttle scopes.
+    """
+
+    def setUp(self):
+        cache.clear()
+        RateLimitMiddleware._requests.clear()
+        self.addCleanup(cache.clear)
+        self.addCleanup(RateLimitMiddleware._requests.clear)
+
+    def _register_payload(self, suffix):
+        return {
+            'email': f'throttle_signup_{suffix}@example.com',
+            'password': 'StrongPass123!',
+            'organization_name': f'Throttle Org {suffix}',
+        }
+
+    def test_signup_allowed_within_limit(self):
+        """First request under the signup limit should not be throttled."""
+        response = self.client.post(
+            '/api/v1/auth/register/',
+            self._register_payload('ok'),
+            format='json',
+        )
+        self.assertNotEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_signup_blocked_after_limit(self):
+        """
+        Signup scope is configured at 5/min. The 6th request in the same
+        window must be throttled regardless of payload validity.
+        """
+        last_response = None
+        for i in range(6):
+            last_response = self.client.post(
+                '/api/v1/auth/register/',
+                self._register_payload(f'block{i}'),
+                format='json',
+            )
+        self.assertEqual(last_response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_login_throttle_is_independent_of_signup_throttle(self):
+        """
+        Exhausting the signup limit must not affect the login endpoint's
+        separate throttle scope (proves scoping works, not just a shared
+        global limiter).
+        """
+        for i in range(6):
+            self.client.post(
+                '/api/v1/auth/register/',
+                self._register_payload(f'iso{i}'),
+                format='json',
+            )
+        login_response = self.client.post(
+            '/api/v1/token/',
+            {'email': 'nonexistent@example.com', 'password': 'wrong'},
+            format='json',
+        )
+        # Should be 401 (bad credentials), not 429 — proves separate scope.
+        self.assertEqual(login_response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class LoginThrottleTests(APITestCase):
+    """
+    Covers issue #18: login endpoint must throttle unauthenticated
+    requests by IP to mitigate brute-force attempts.
+    """
+
+    def setUp(self):
+        cache.clear()
+        RateLimitMiddleware._requests.clear()
+        self.addCleanup(cache.clear)
+        self.addCleanup(RateLimitMiddleware._requests.clear)
+
+    def test_login_allowed_within_limit(self):
+        response = self.client.post(
+            '/api/v1/token/',
+            {'email': 'nobody@example.com', 'password': 'wrong'},
+            format='json',
+        )
+        self.assertNotEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_login_blocked_after_limit(self):
+        """
+        Login scope is configured at 10/min. The 11th request in the same
+        window must be throttled regardless of credential validity.
+        """
+        last_response = None
+        for _ in range(11):
+            last_response = self.client.post(
+                '/api/v1/token/',
+                {'email': 'nobody@example.com', 'password': 'wrong'},
+                format='json',
+            )
+        self.assertEqual(last_response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -8,8 +8,14 @@ from .models import User
 from .permissions import IsOrgAdmin
 from .serializers import UserSerializer, RegisterSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
+from backend.throttles import SignupRateThrottle
 
 class AuthViewSet(viewsets.GenericViewSet):
+    def get_throttles(self):
+        if self.action == 'register':
+            return [SignupRateThrottle()]
+        return super().get_throttles()
+
     @action(detail=False, methods=['post'], permission_classes=[AllowAny])
     def register(self, request):
         serializer = RegisterSerializer(data=request.data)


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue
Closes #18 

---

## 📝 Summary of Changes
Adds DRF-based rate limiting to protect four sensitive API endpoints from abuse, spam, and brute-force attacks, as requested in issue #18:

- **Login** (`POST /api/v1/token/`) — throttled by IP via `AnonRateThrottle` (10/min)
- **Signup** (`POST /api/v1/auth/register/`) — throttled by IP via `AnonRateThrottle` (5/min)
- **Campaign launch** (`POST /api/v1/campaigns/{id}/launch/`) — throttled per authenticated user via `UserRateThrottle` (20/min)
- **AI draft generation** (`POST /api/v1/campaigns/ai-generate/`) — throttled per authenticated user via `UserRateThrottle` (15/min)

**Implementation details:**
- New `backend/backend/throttles.py` centralizes all scoped throttle classes (`LoginRateThrottle`, `SignupRateThrottle`, `CampaignLaunchThrottle`, `AIDraftThrottle`), so rate limits are configurable via `settings.py` rather than hardcoded in views.
- Throttle rates are defined in `REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]` in `settings.py` — easy to tune without touching view code.
- Each throttle is scoped to only the relevant action (e.g. `get_throttles()` overrides on `AuthViewSet` and `CampaignViewSet` apply throttling only to `register` and `launch` respectively) — other actions like `me`, `enroll`, `pause`, `resume`, and `metrics` are unaffected.
- Uses Django's cache framework under the hood, so this remains compatible with distributed deployments (e.g. shared Redis cache across multiple app instances) without further code changes.
- The existing `tenants.security.RateLimitMiddleware` (a global, IP-based, in-memory 100 req/min limiter) was intentionally left untouched — it operates independently at the middleware layer, while this PR adds finer-grained, per-endpoint limits at the DRF view layer. The two are complementary, not duplicated.

**Aside (unrelated to this issue):** while setting up a fresh environment, I noticed `beautifulsoup4` is imported in `campaigns/tasks.py` but missing from `requirements.txt`. Happy to open a separate 1-line PR for that if useful.

---

## 🏷️ Type of Change
* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing
Added `backend/users/test_throttling.py` and `backend/campaigns/test_throttling.py`, covering both allowed and rate-limited requests for authenticated and unauthenticated scenarios, plus scope-independence (e.g. exhausting the signup limit doesn't affect login).

**Steps to test:**
1. Run the full suite: `cd backend && python manage.py test` — all 102 tests pass (92 pre-existing + 10 new throttling tests).
2. Manually verify login throttling: send 11 rapid `POST` requests to `/api/v1/token/` with invalid credentials — first 10 return `401`, the 11th returns `429`.
3. Manually verify signup, campaign launch, and AI-generate throttling the same way, using their respective limits (5/min, 20/min, 15/min).

**Before vs after behavior (captured via PowerShell `Invoke-WebRequest`):**

*Login (limit 10/min):*
1–10: 401 {"detail":"No active account found with the given credentials"}
11:   429 {"detail":"Request was throttled. Expected available in 56 seconds."}

*Signup (limit 5/min):*
1–5: 400 {"organization_name":["This field is required."]}
6:   429 {"detail":"Request was throttled. Expected available in 60 seconds."}

*AI draft generation (limit 15/min):*
1–15: 200 (fallback draft returned, no Gemini key configured)
16:   429 {"detail":"Request was throttled. Expected available in 60 seconds."}

---

## 📸 Screenshots (if applicable)
N/A — backend API changes only, no UI impact.

---

## ✅ Checklist
* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [x] Related issue linked
* [x] Changes tested locally (if applicable)


Aside (unrelated to this issue): while setting up a fresh environment, I noticed beautifulsoup4 is used in campaigns/tasks.py but missing from requirements.txt. Happy to open a separate 1-line PR for that if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to login and signup (separate limits) to help protect authentication endpoints.
  * Added rate limiting to campaign launch and AI draft generation, with independent per-scope quotas.
* **Bug Fixes**
  * Ensured throttling for one action scope doesn’t throttle unrelated endpoints.
* **Tests**
  * Added automated tests covering authenticated and unauthenticated throttling behavior, including expected HTTP 429 responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->