### PR TITLE
feat: add warning modal before deleting connected email account

### DIFF
--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -400,7 +400,7 @@
         }
 
         async function deleteConnectedAccount(accountId) {
-            showConfirmModal('Remove Email Account', 'Remove this connected sender account from LeadOrbit?', 'Remove', async () => {
+            showConfirmModal('Remove Email Account', 'Warning: Deleting this sender account will immediately pause all campaigns currently scheduled to send from it. Are you sure you want to disconnect?', 'Remove', async () => {
                 try {
                     const res = await fetchWithAuth(`/connected-accounts/${accountId}/`, { method: 'DELETE' });
                     if (!res.ok && res.status !== 204) {


### PR DESCRIPTION
## 🔗 Related Issue
Closes #559

## 📝 Summary of Changes
- Added a warning confirmation modal before deleting a connected email account.
- Updated the confirmation message to clearly inform users that deleting the sender account will pause all campaigns using it.
- Preserved the existing delete functionality after user confirmation.

## 🏷️ Type of Change
- 🎨 UI / UX Improvement

## 🧪 Testing
- Verified the warning message is displayed before deletion.
- Confirmed the existing delete flow remains unchanged after confirmation.

## 📸 Screenshots
N/A

## ✅ Checklist
- [x] No merge conflicts
- [x] Changes follow the project guidelines
- [x] Related issue linked
- [x] Tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the removal confirmation message for connected email accounts to clearly warn that deleting the sender account will immediately pause any campaigns scheduled to send from it.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->