### PR TITLE
fix: trim whitespace from custom csv headers

### DIFF
--- a/backend/leads/tasks.py
+++ b/backend/leads/tasks.py
@@ -83,7 +83,8 @@ def import_leads_from_csv(file_contents, organization_id, job_id=None):
     except csv.Error:
         dialect = csv.excel
     reader = csv.DictReader(stream, dialect=dialect)
-
+    if reader.fieldnames:
+        reader.fieldnames = [name.strip() for name in reader.fieldnames]
     leads_created = 0
     leads_updated = 0
     failed_count = 0

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -88,6 +88,20 @@ class LeadImportTests(APITestCase):
         self.assertTrue(Lead.objects.filter(organization=self.organization, email='valid@example.com').exists())
         self.assertEqual(job.error_log[0]['error'], 'Invalid email format')
         self.assertEqual(job.error_log[1]['error'], 'Missing email address')
+        
+    def test_import_trims_whitespace_from_csv_headers(self):
+        # Everything here must have the same indentation
+        csv_data = (
+            " Email , First Name , Last Name , Company Name \n"
+            "alice@example.com,Alice,Smith,Acme\n"
+        )
+        
+        import_leads_from_csv(csv_data, str(self.organization.id))
+        
+        lead = Lead.objects.get(organization=self.organization, email='alice@example.com')
+        self.assertEqual(lead.first_name, 'Alice')
+        self.assertEqual(lead.last_name, 'Smith')
+        self.assertEqual(lead.company, 'Acme')   
 
 
 class LeadIsolationAPITests(APITestCase):
@@ -461,3 +475,5 @@ class LeadFilterTests(APITestCase):
         resp = self._get()
         emails = {l['email'] for l in resp.data}
         self.assertNotIn('spy@example.com', emails)
+
+    


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #558

---

## 📝 Summary of Changes
This PR resolves Issue #558 by sanitizing CSV headers during the lead import process. It prevents automapping failures and validation errors caused by hidden leading or trailing whitespace in user-uploaded CSV column names.

---

## 🏷️ Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

The fix ensures the `csv.DictReader` processes headers as clean strings before they are mapped to the database schema.

**Steps to test:**

1.Create a local CSV file with intentionally messy headers (e.g., `" Email ", " First Name "`).

2.Run the `import_leads_from_csv` task.

3.Verify that the system successfully maps these columns to the email and first_name fields without triggering validation errors.

4.Run `python manage.py` test to ensure no regressions in existing logic.

## 📸 Screenshots

<img width="1760" height="584" alt="Screenshot (1251)" src="https://github.com/user-attachments/assets/af1591c8-36c1-484b-acbe-a276383675fb" />


## ✅ Checklist

* [ ] No merge conflicts
* [ ] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [ ] Related issue linked
* [ ] Changes tested locally (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV lead imports to trim extra whitespace from header names, preventing mismatches during field mapping.
  * Lead details from CSV uploads (including names and company) are now more reliably imported when column headers are inconsistently padded.
* **Tests**
  * Added coverage to verify whitespace-trimmed CSV header import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->