### PR TITLE
fix: trim whitespace from CSV headers during import

### DIFF
--- a/backend/leads/tasks.py
+++ b/backend/leads/tasks.py
@@ -84,6 +84,17 @@ def import_leads_from_csv(file_contents, organization_id, job_id=None):
         dialect = csv.excel
     reader = csv.DictReader(stream, dialect=dialect)
 
+# Trim leading/trailing whitespace from CSV headers
+    if reader.fieldnames:
+
+        reader.fieldnames = [
+
+            header.strip() if header is not None else None
+
+            for header in reader.fieldnames
+
+        ]
+
     leads_created = 0
     leads_updated = 0
     failed_count = 0


### PR DESCRIPTION
## 🔗 Related Issue

Closes #558

---

## 📝 Summary of Changes

- Trim leading and trailing whitespace from CSV headers before processing.
- Preserve `None` header values to avoid errors.
- Ensure headers like `" Email "` are correctly recognized during import.

---

## 👉 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation update
- [ ] 🎨 UI / Style change
- [ ] 🔧 Chore

---

## 🧪 Testing

- Tested by reviewing the CSV import logic.
- Verified that headers are stripped before processing.
- Existing functionality remains unchanged for valid CSV files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV lead imports by handling extra whitespace in column headers more reliably, reducing mismatches when mapping fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->