### PR TITLE
Validate pagination parameters in campaign leads endpoint

### DIFF
--- a/backend/campaigns/views.py
+++ b/backend/campaigns/views.py
@@ -269,8 +269,17 @@ class CampaignViewSet(viewsets.ModelViewSet):
         """Get paginated list of enrolled leads with metrics."""
         campaign = self.get_object()
         status_filter = request.query_params.get('status')
-        limit = int(request.query_params.get('limit', 50))
-        offset = int(request.query_params.get('offset', 0))
+        try:
+            limit = int(request.query_params.get("limit", 50))
+            offset = int(request.query_params.get("offset", 0))
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "limit and offset must be integers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        limit = max(1, min(limit, 200))
+
+        offset = max(0, offset)
 
         leads_qs = campaign.enrolled_leads.select_related('lead').order_by('-updated_at')
 


### PR DESCRIPTION
## Summary

This PR fixes Issue #55 by validating pagination query parameters in the campaign leads endpoint.

### Changes

- Added validation for `limit` and `offset` query parameters.

- Returns HTTP 400 when either parameter is not a valid integer.

- Clamps `limit` to a maximum of 200.

- Prevents negative `offset` values by defaulting them to 0.

### Testing

- Verified valid integer values work correctly.

- Verified invalid values return HTTP 400.

- Verified negative offsets are normalized to 0.

- Verified large limits are capped at 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination handling for campaign leads by validating page size and position values.
  * Invalid values now return a clear bad request response instead of causing a server error.
  * Page size is now kept within a safe range, and negative positions are no longer accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->