### PR TITLE
feat: auto-pause campaign if initial bounce rate exceeds threshold (#…

### DIFF
--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 from celery import shared_task
 from django.conf import settings as django_settings
 from django.core.signing import Signer
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -22,7 +23,7 @@ from .mailbox_service import (
     mark_imap_message_as_read,
     send_smtp_email,
 )
-from .notifications import notify_email_bounced
+from .notifications import notify_email_bounced, send_notification
 from .sms_service import initiate_call, send_sms
 from .models import CampaignLead, ConnectedEmailAccount, SequenceStep
 from leads.models import BlockedDomain, normalize_domain
@@ -113,7 +114,7 @@ def _activate_step(clead, step, now=None):
 
 
 def _maybe_mark_campaign_completed(campaign):
-    if campaign.status == 'COMPLETED':
+    if campaign.status in ('COMPLETED', 'PAUSED'):
         return
 
     if not campaign.enrolled_leads.exists():
@@ -124,9 +125,42 @@ def _maybe_mark_campaign_completed(campaign):
     if has_unfinished:
         return
 
-    campaign.status = 'COMPLETED'
-    campaign.save(update_fields=['status'])
-    logger.info(f"Campaign marked COMPLETED: {campaign.id}")
+    updated = type(campaign).objects.filter(
+        id=campaign.id
+    ).exclude(
+        status='PAUSED'
+    ).update(status='COMPLETED')
+    
+    if updated:
+        campaign.status = 'COMPLETED'
+        logger.info(f"Campaign marked COMPLETED: {campaign.id}")
+
+def _check_campaign_health_for_bounces(campaign_id):
+    from .models import Campaign
+    with transaction.atomic():
+        try:
+            campaign = Campaign.objects.select_for_update().get(id=campaign_id)
+        except Campaign.DoesNotExist:
+            return
+
+        if campaign.status == 'PAUSED':
+            return
+
+        if campaign.sent_count >= 50:
+            bounce_rate = campaign.bounced_count / campaign.sent_count
+            if bounce_rate > 0.10:
+                campaign.status = 'PAUSED'
+                campaign.save(update_fields=['status'])
+                logger.info(f"Campaign {campaign.id} auto-paused due to high bounce rate.")
+                send_notification(
+                    campaign.organization_id,
+                    'campaign_paused',
+                    {
+                        'message': 'Campaign Auto-Paused due to high bounce rates',
+                        'campaign_id': str(campaign.id)
+                    }
+                )
+
 
 
 def _mark_campaign_lead_bounced(
@@ -164,6 +198,7 @@ def _mark_campaign_lead_bounced(
 
     if not was_bounced:
         notify_email_bounced(clead.organization_id, clead.lead.email)
+        _check_campaign_health_for_bounces(clead.campaign_id)
     _maybe_mark_campaign_completed(clead.campaign)
     logger.info(
         "Bounce detected for %s in campaign %s at %s (type=%s, code=%s)",

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -152,13 +152,15 @@ def _check_campaign_health_for_bounces(campaign_id):
                 campaign.status = 'PAUSED'
                 campaign.save(update_fields=['status'])
                 logger.info(f"Campaign {campaign.id} auto-paused due to high bounce rate.")
-                send_notification(
-                    campaign.organization_id,
-                    'campaign_paused',
-                    {
-                        'message': 'Campaign Auto-Paused due to high bounce rates',
-                        'campaign_id': str(campaign.id)
-                    }
+                transaction.on_commit(
+                    lambda: send_notification(
+                        campaign.organization_id,
+                        'campaign_paused',
+                        {
+                            'message': 'Campaign Auto-Paused due to high bounce rates',
+                            'campaign_id': str(campaign.id)
+                        }
+                    )
                 )
 
 

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -2067,7 +2067,7 @@ class CampaignAutoPauseTests(APITestCase):
             campaign=self.campaign,
             lead=lead,
             current_step=self.step,
-            status='ACTIVE'
+            status='BOUNCED'
         )
         
         from campaigns.tasks import _check_campaign_health_for_bounces, _maybe_mark_campaign_completed

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -1961,3 +1961,119 @@ class GoogleOAuthStateTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertIn('google_auth=error', response['Location'])
         self.assertIn('reason=no_user', response['Location'])
+
+class CampaignAutoPauseTests(APITestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name='Acme Corp')
+        self.user = User.objects.create_user(
+            email='admin@acme.test',
+            password='password123',
+            organization=self.organization
+        )
+        self.campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Test Pause Campaign',
+            status='ACTIVE',
+            sent_count=0,
+            bounced_count=0
+        )
+        self.step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=self.campaign,
+            step_order=1,
+            channel_type='EMAIL'
+        )
+
+    def test_auto_pause_does_not_trigger_below_50_sent(self):
+        self.campaign.sent_count = 49
+        self.campaign.bounced_count = 10  # > 10%
+        self.campaign.save()
+
+        lead = Lead.objects.create(organization=self.organization, email='b1@acme.test')
+        clead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=self.campaign,
+            lead=lead,
+            current_step=self.step,
+            status='ACTIVE'
+        )
+        
+        with patch('campaigns.tasks.send_notification') as mock_notify:
+            from campaigns.tasks import _mark_campaign_lead_bounced
+            _mark_campaign_lead_bounced(clead)
+            
+        self.campaign.refresh_from_db()
+        self.assertEqual(self.campaign.status, 'ACTIVE')
+        mock_notify.assert_not_called()
+
+    def test_auto_pause_triggers_at_50_sent_with_high_bounce_rate(self):
+        self.campaign.sent_count = 50
+        self.campaign.bounced_count = 6
+        self.campaign.save()
+
+        lead = Lead.objects.create(organization=self.organization, email='b2@acme.test')
+        clead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=self.campaign,
+            lead=lead,
+            current_step=self.step,
+            status='ACTIVE'
+        )
+        
+        with patch('campaigns.tasks.send_notification') as mock_notify:
+            from campaigns.tasks import _mark_campaign_lead_bounced
+            _mark_campaign_lead_bounced(clead)
+            
+        self.campaign.refresh_from_db()
+        self.assertEqual(self.campaign.status, 'PAUSED')
+        mock_notify.assert_called_once_with(
+            self.organization.id,
+            'campaign_paused',
+            {
+                'message': 'Campaign Auto-Paused due to high bounce rates',
+                'campaign_id': str(self.campaign.id)
+            }
+        )
+
+    def test_already_paused_campaign_no_duplicate_notification(self):
+        self.campaign.status = 'PAUSED'
+        self.campaign.sent_count = 100
+        self.campaign.bounced_count = 20
+        self.campaign.save()
+
+        lead = Lead.objects.create(organization=self.organization, email='b3@acme.test')
+        clead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=self.campaign,
+            lead=lead,
+            current_step=self.step,
+            status='ACTIVE'
+        )
+        
+        with patch('campaigns.tasks.send_notification') as mock_notify:
+            from campaigns.tasks import _mark_campaign_lead_bounced
+            _mark_campaign_lead_bounced(clead)
+            
+        mock_notify.assert_not_called()
+
+    def test_pause_priority_over_completion(self):
+        self.campaign.sent_count = 100
+        self.campaign.bounced_count = 20
+        self.campaign.save()
+
+        lead = Lead.objects.create(organization=self.organization, email='b4@acme.test')
+        clead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=self.campaign,
+            lead=lead,
+            current_step=self.step,
+            status='ACTIVE'
+        )
+        
+        from campaigns.tasks import _check_campaign_health_for_bounces, _maybe_mark_campaign_completed
+        
+        _check_campaign_health_for_bounces(self.campaign.id)
+        _maybe_mark_campaign_completed(self.campaign)
+        
+        self.campaign.refresh_from_db()
+        self.assertEqual(self.campaign.status, 'PAUSED')


### PR DESCRIPTION
## Related Issue

Closes #480

## Summary

Implemented automatic campaign pausing when the initial bounce rate exceeds 10% after at least 50 emails have been sent.

### Changes
- Added automatic campaign health check after bounce events.
- Auto-pauses campaigns when bounce rate exceeds the configured threshold.
- Prevents COMPLETED from overriding PAUSED status.
- Uses database locking to reduce race conditions during pause evaluation.
- Sends notification to organization admins when a campaign is auto-paused.
- Added backend tests covering:
  - Less than 50 sent emails
  - Threshold reached
  - Already paused campaigns
  - Pause priority over completion

## Type of Change

- [x] New feature

## Testing

- [x] Backend tests executed
- [x] Auto-pause behavior verified
- [x] Existing functionality remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaigns now auto-pause when at least 50 messages have been sent and the bounce rate exceeds 10%.
  * When a campaign is auto-paused, a pause notification is emitted (only once per pause event).
* **Bug Fixes**
  * Paused campaigns no longer receive additional completion processing.
  * Bounce events that occur after a campaign is already paused won’t trigger duplicate pause notifications.
  * Pausing now takes priority over completion-related outcomes.
* **Tests**
  * Added automated test coverage for bounce-rate-driven auto-pause behavior and priority rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->