### PR TITLE
fix: prevent theme flash on settings page and remove duplicate main.js import

### DIFF
--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -1226,8 +1226,6 @@
     </div>
   </div>
 </div>
-
-    <script type="module" src="/main.js"></script>
     <script type="module">
         import { fetchWithAuth } from './api.js';
 

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="./theme-boot.js"></script>
     <title>Settings - LeadOrbit</title>
     <meta name="description" content="LeadOrbit - Settings. Configure your account, integrations, API keys, and preferences.">
     <meta name="keywords" content="settings, account settings, integrations, API keys">


### PR DESCRIPTION
## Description
Theme persistence (localStorage + restore on load) is already implemented via `theme-boot.js` and `main.js`. This PR fixes two gaps that undermined it:

1. `settings.html` was missing `theme-boot.js` in `<head>`, causing a flash of light mode on load — the one page with the actual toggle switch.
2. `campaign-builder.html` imported `main.js` twice, double-registering theme and other event listeners.

Resolves #503.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete campaign-building experience for creating, editing, sequencing, and launching campaigns.
  * Added conditional yes/no branching, lead selection and enrollment, connected-account loading, and campaign restoration from saved campaigns.
  * Added email template loading and insertion.
  * Added AI Email Studio for generating and inserting email content.
  * Added campaign settings and launch controls.
* **Style**
  * Improved theme initialization on the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->