### PR TITLE
feat: Persist Gemini API key from Settings UI to the backend

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -5,7 +5,7 @@ from tenants.models import Organization
 class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization
-        fields = '__all__'
+        exclude = ['gemini_api_key']
 
 class UserSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer(read_only=True)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -48,13 +48,13 @@ class AuthViewSet(viewsets.GenericViewSet):
                 request.user.organization.name = clean_name
                 request.user.organization.save(update_fields=['name'])
                 updates_made = True
-            if gemini_api_key is not None:
+            if 'gemini_api_key' in payload:
                 if not IsOrgAdmin().has_permission(request, self):
                     return Response(
                         {'detail': 'Only organization admins can update organization settings.'},
                         status=status.HTTP_403_FORBIDDEN,
                     )
-                request.user.organization.gemini_api_key = str(gemini_api_key).strip() or None
+                request.user.organization.gemini_api_key = str(gemini_api_key).strip() if gemini_api_key else None
                 request.user.organization.save(update_fields=['gemini_api_key'])
                 updates_made = True
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -43,7 +43,8 @@ class AuthViewSet(viewsets.GenericViewSet):
 
             if organization_name is not None:
                 denied = _check_org_admin(request, self)
-                if denied: return denied
+                if denied:
+                    return denied
                 clean_name = str(organization_name).strip()
                 if not clean_name:
                     return Response(
@@ -55,7 +56,8 @@ class AuthViewSet(viewsets.GenericViewSet):
                 updates_made = True
             if 'gemini_api_key' in payload:
                 denied = _check_org_admin(request, self)
-                if denied: return denied
+                if denied:
+                    return denied
                 request.user.organization.gemini_api_key = str(gemini_api_key).strip() if gemini_api_key else None
                 if not request.user.organization.gemini_api_key:
                     request.user.organization.gemini_api_key = None
@@ -64,7 +66,8 @@ class AuthViewSet(viewsets.GenericViewSet):
 
             if enable_ai_personalization is not None:
                 denied = _check_org_admin(request, self)
-                if denied: return denied
+                if denied:
+                    return denied
                 request.user.organization.enable_ai_personalization = bool(enable_ai_personalization)
                 request.user.organization.save(update_fields=['enable_ai_personalization'])
                 updates_made = True

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -9,6 +9,14 @@ from .permissions import IsOrgAdmin
 from .serializers import UserSerializer, RegisterSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 
+def _check_org_admin(request, viewset):
+    if not IsOrgAdmin().has_permission(request, viewset):
+        return Response(
+            {'detail': 'Only organization admins can update organization settings.'},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+    return None
+
 class AuthViewSet(viewsets.GenericViewSet):
     @action(detail=False, methods=['post'], permission_classes=[AllowAny])
     def register(self, request):
@@ -34,11 +42,8 @@ class AuthViewSet(viewsets.GenericViewSet):
             enable_ai_personalization = payload.get('enable_ai_personalization')
 
             if organization_name is not None:
-                if not IsOrgAdmin().has_permission(request, self):
-                    return Response(
-                        {'detail': 'Only organization admins can update organization settings.'},
-                        status=status.HTTP_403_FORBIDDEN,
-                    )
+                denied = _check_org_admin(request, self)
+                if denied: return denied
                 clean_name = str(organization_name).strip()
                 if not clean_name:
                     return Response(
@@ -49,21 +54,17 @@ class AuthViewSet(viewsets.GenericViewSet):
                 request.user.organization.save(update_fields=['name'])
                 updates_made = True
             if 'gemini_api_key' in payload:
-                if not IsOrgAdmin().has_permission(request, self):
-                    return Response(
-                        {'detail': 'Only organization admins can update organization settings.'},
-                        status=status.HTTP_403_FORBIDDEN,
-                    )
+                denied = _check_org_admin(request, self)
+                if denied: return denied
                 request.user.organization.gemini_api_key = str(gemini_api_key).strip() if gemini_api_key else None
+                if not request.user.organization.gemini_api_key:
+                    request.user.organization.gemini_api_key = None
                 request.user.organization.save(update_fields=['gemini_api_key'])
                 updates_made = True
 
             if enable_ai_personalization is not None:
-                if not IsOrgAdmin().has_permission(request, self):
-                    return Response(
-                        {'detail': 'Only organization admins can update organization settings.'},
-                        status=status.HTTP_403_FORBIDDEN,
-                    )
+                denied = _check_org_admin(request, self)
+                if denied: return denied
                 request.user.organization.enable_ai_personalization = bool(enable_ai_personalization)
                 request.user.organization.save(update_fields=['enable_ai_personalization'])
                 updates_made = True


### PR DESCRIPTION
Fixes #648 by properly checking for the presence of the \gemini_api_key\ key in the payload rather than checking for \is not None\. This ensures that setting the key to null (clearing it) correctly persists to the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini API key updates in organization settings: saving now occurs whenever the key is included in the request.
  * Submitted values are trimmed before saving, and sending a falsy value now clears the stored API key.
  * Organization setting updates now consistently enforce admin permissions.

* **Security / Privacy**
  * The Gemini API key is no longer included in organization data responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->