### PR TITLE
fix: add pagination to lead listing API

### DIFF
--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -136,7 +136,7 @@ class LeadIsolationAPITests(APITestCase):
         self.client.force_authenticate(self.user_a)
         response = self.client.get('/api/v1/leads/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        emails = {item['email'] for item in response.data}
+        emails = {item['email'] for item in response.data['results']}
         self.assertIn(self.lead_a.email, emails)
         self.assertNotIn(self.lead_b.email, emails)
 
@@ -401,21 +401,21 @@ class LeadFilterTests(APITestCase):
     def test_filter_by_status_active(self):
         resp = self._get(status='active')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        emails = {l['email'] for l in resp.data}
+        emails = {l['email'] for l in resp.data['results']}
         self.assertNotIn('unsub@example.com', emails)
         self.assertIn('active@example.com', emails)
 
     def test_filter_by_status_unsubscribed(self):
         resp = self._get(status='unsubscribed')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        emails = {l['email'] for l in resp.data}
+        emails = {l['email'] for l in resp.data['results']}
         self.assertIn('unsub@example.com', emails)
         self.assertNotIn('active@example.com', emails)
 
     def test_filter_by_single_tag(self):
         resp = self._get(tags=str(self.tag_vip.id))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        emails = {l['email'] for l in resp.data}
+        emails = {l['email'] for l in resp.data['results']}
         self.assertIn('vip@example.com', emails)
         self.assertNotIn('cold@example.com', emails)
         self.assertNotIn('active@example.com', emails)
@@ -425,7 +425,7 @@ class LeadFilterTests(APITestCase):
         LeadTag.objects.create(lead=self.lead_vip, tag=self.tag_cold, organization=self.org)
         resp = self._get(tags=f'{self.tag_vip.id},{self.tag_cold.id}')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        emails = {l['email'] for l in resp.data}
+        emails = {l['email'] for l in resp.data['results']}
         # lead_vip has both tags — should appear
         self.assertIn('vip@example.com', emails)
         # lead_cold only has tag_cold — should NOT appear (missing tag_vip)
@@ -435,17 +435,17 @@ class LeadFilterTests(APITestCase):
         resp = self._get(created_after='1970-01-01')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         # All leads were created after 1970; all should be returned
-        self.assertGreaterEqual(len(resp.data), 4)
+        self.assertGreaterEqual(len(resp.data['results']), 4)
 
     def test_filter_by_created_before_far_future(self):
         resp = self._get(created_before='2099-12-31')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertGreaterEqual(len(resp.data), 4)
+        self.assertGreaterEqual(len(resp.data['results']), 4)
 
     def test_combined_tag_and_status_filter(self):
         resp = self._get(tags=str(self.tag_vip.id), status='active')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        emails = {l['email'] for l in resp.data}
+        emails = {l['email'] for l in resp.data['results']}
         self.assertIn('vip@example.com', emails)
         self.assertNotIn('unsub@example.com', emails)
         self.assertNotIn('cold@example.com', emails)
@@ -453,11 +453,51 @@ class LeadFilterTests(APITestCase):
     def test_no_filter_returns_all_org_leads(self):
         resp = self._get()
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(resp.data), 4)
+        self.assertEqual(len(resp.data['results']), 4)
 
     def test_filter_does_not_leak_other_org_leads(self):
         other_org = Organization.objects.create(name='Spy Org')
         _make_lead(other_org, 'spy@example.com')
         resp = self._get()
-        emails = {l['email'] for l in resp.data}
+        emails = {l['email'] for l in resp.data['results']}
         self.assertNotIn('spy@example.com', emails)
+
+
+class LeadPaginationAPITests(APITestCase):
+    """Tests pagination behavior for GET /api/v1/leads/"""
+
+    def setUp(self):
+        self.org = Organization.objects.create(name='Pagination Org')
+        self.user = _make_user(self.org, email='paginator@example.com')
+        # Create 60 leads so we can test page 1, page 2 and page size query parameter
+        self.leads = [
+            _make_lead(self.org, f'lead{i}@example.com') for i in range(60)
+        ]
+
+    def test_pagination_defaults_to_50_per_page(self):
+        self.client.force_authenticate(self.user)
+        resp = self.client.get('/api/v1/leads/')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('count', resp.data)
+        self.assertIn('next', resp.data)
+        self.assertIn('previous', resp.data)
+        self.assertIn('results', resp.data)
+        self.assertEqual(resp.data['count'], 60)
+        self.assertEqual(len(resp.data['results']), 50)
+
+    def test_pagination_page_size_query_param(self):
+        self.client.force_authenticate(self.user)
+        # Request page size of 10
+        resp = self.client.get('/api/v1/leads/', {'page_size': 10})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data['results']), 10)
+
+    def test_pagination_max_page_size(self):
+        self.client.force_authenticate(self.user)
+        # Create extra leads to exceed 200
+        for i in range(60, 250):
+            _make_lead(self.org, f'lead{i}@example.com')
+        # Request page size of 300
+        resp = self.client.get('/api/v1/leads/', {'page_size': 300})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data['results']), 200) # capped at max_page_size

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -12,8 +12,15 @@ class LeadImportJobPagination(PageNumberPagination):
     page_size = 10
 
 
+class LeadPagination(PageNumberPagination):
+    page_size = 50
+    page_size_query_param = 'page_size'
+    max_page_size = 200
+
+
 class LeadViewSet(viewsets.ModelViewSet):
     serializer_class = LeadSerializer
+    pagination_class = LeadPagination
     queryset = Lead.objects.all()
     manager_actions = frozenset({
         'create',
@@ -78,7 +85,7 @@ class LeadViewSet(viewsets.ModelViewSet):
                 | Q(company__icontains=search)
             )
 
-        return qs.distinct()
+        return qs.distinct().order_by('-created_at')
 
     def perform_create(self, serializer):
         serializer.save(organization=self.request.user.organization)


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #458
---

## 📝 Summary of Changes

- Added a dedicated LeadPagination class using Django REST Framework PageNumberPagination.
- Applied pagination only to LeadViewSet.
- Added support for the page_size query parameter.
- Limited the maximum page size to 200.
- Added deterministic ordering using -created_at.
- Updated existing tests and added pagination-specific tests.

---

## 🏷️ Type of Change

* [x ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

Executed the lead test suite locally.

Command used:

```bash
python manage.py test leads

**Steps to test:**
1. Run the backend server.
2. Send a GET request to /api/v1/leads/.
3. Verify the response includes count, next, previous and results.
4. Test page_size query parameter (e.g. ?page_size=10).
5. Verify page_size greater than 200 is capped at 200.

---

## 📸 Screenshots (if applicable)
Not applicable.

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [x] Related issue linked
* [x] Changes tested locally (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lead listings now support pagination with 50 leads per page by default.
  * Page size can be customized through the `page_size` parameter, up to 200 leads.

* **Improvements**
  * Leads are consistently displayed from newest to oldest.
  * Lead filters continue to work correctly across paginated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->