### PR TITLE
fix: trim whitespace in login and registration serializers (#474)

### DIFF
--- a/backend/users/jwt.py
+++ b/backend/users/jwt.py
@@ -2,3 +2,11 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 class CustomTokenObtainSerializer(TokenObtainPairSerializer):
     username_field = 'email'
+
+    def validate(self, attrs):
+        # Strip stray whitespace from copy-pasted emails (Issue #474).
+        # Password is intentionally left untouched.
+        if isinstance(attrs.get(self.username_field), str):
+            attrs[self.username_field] = attrs[self.username_field].strip()
+        return super().validate(attrs)
+    

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -21,9 +21,16 @@ class RegisterSerializer(serializers.Serializer):
     last_name = serializers.CharField(required=False)
 
     def validate_email(self, value):
+        value = value.strip()
         if User.objects.filter(email__iexact=value).exists():
             raise serializers.ValidationError('A user with this email already exists.')
         return value
+
+    def validate_first_name(self, value):
+        return value.strip() if value else value
+
+    def validate_last_name(self, value):
+        return value.strip() if value else value
 
     def create(self, validated_data):
         org = Organization.objects.create(name=validated_data['organization_name'])


### PR DESCRIPTION
## Description
PR #518 covers the frontend half of #474 (trimming login/register inputs before submission), but CodeRabbit's own review on that PR flagged that the backend serializer trimming requested by the issue was still missing.

This PR adds that missing half. No frontend files touched, no overlap with #518.

## Changes
- [x] `CustomTokenObtainSerializer.validate`: trims email before authentication (login)
- [x] `RegisterSerializer`: trims email, first_name, and last_name (registration)
- [x] Password is left untouched in both, matching the same rule CodeRabbit enforced on the frontend PR

## Checklist
- [x] Tested locally
- [x] No breaking changes to existing tests
- [x] Follows repo contribution guidelines

Complements #518. Related to #474.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration and sign-in reliability by automatically removing extra spaces from email addresses, usernames, and names.
  * Prevented accidental duplicate-account issues caused by leading or trailing whitespace in email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->