### PR TITLE
feat: add dynamic page title on tab visibility change

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -606,3 +606,13 @@ if (document.readyState === 'loading') {
 } else {
     initKeyboardShortcuts();
 }
+    
+const originalTitle = document.title;
+
+document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+        document.title = "Come back to LeadOrbit!";
+    } else {
+        document.title = originalTitle;
+    }
+});


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #400 

---

## 📝 Summary of Changes

- Added a Page Visibility API listener in frontend/main.js.
- Changes the browser tab title to "Come back to LeadOrbit!" when the user switches to another tab.
- Restores the original page title when the user returns to the LeadOrbit tab.

---

## 🏷️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

Tested locally in the browser.

Steps to test:
1. Open the LeadOrbit application in a browser.
2. Switch to another browser tab.
3. Verify the tab title changes to "Come back to LeadOrbit!".
4. Return to the LeadOrbit tab.
5. Verify the original page title is restored.
---

## 📸 Screenshots (if applicable)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a1410f96-f835-461e-b0ab-c26116da0d10" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d96f3d9d-384a-4bc9-b58a-8ec9b15bb691" />


---

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [x] Related issue linked
* [x] Changes tested locally (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The browser tab title now displays a reminder when the page is hidden and restores its previous title when you return.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->