### PR TITLE
adding email template preview tab

### DIFF
--- a/frontend/campaign-builder.html
+++ b/frontend/campaign-builder.html
@@ -2057,9 +2057,19 @@ ${rows || `
                     <input type="text" class="ep-input" id="ep-subject" placeholder="Subject" value="${step.subject || ''}">
                 </div>
                 <div class="mb-3">
+                <div class="d-flex gap-2 mb-2">
+                    <button class="btn btn-sm btn-primary" id="tab-edit">Edit Template</button>
+                    <button class="btn btn-sm btn-outline-secondary" id="tab-preview">Preview Email</button>
+                </div>
+                <div id="edit-view">
                     <div class="ep-label">Body</div>
                     <textarea class="ep-textarea" id="ep-body" placeholder="Write your email content...">${step.body || ''}</textarea>
                 </div>
+                <div id="preview-view" class="d-none">
+                    <div class="ep-label">Preview</div>
+                    <div id="email-preview-box" class="p-3 rounded-3 border" style="min-height:150px; white-space:pre-wrap; font-family: inherit;"></div>
+                </div>
+            </div>
                 <div class="mb-3">
                     <div class="ep-label">Merge Tags</div>
                     <div class="d-flex flex-wrap gap-2">
@@ -2087,7 +2097,34 @@ ${rows || `
             // Bind inputs
             document.getElementById('ep-subject').addEventListener('input', (e) => { step.subject = e.target.value; });
             document.getElementById('ep-body').addEventListener('input', (e) => { step.body = e.target.value; });
+            // Preview tab logic
+            const MOCK_DATA = {
+                '{{firstName}}': 'John',
+                '{{lastName}}': 'Cena',
+                '{{email}}': 'john.cena@example.com',
+                '{{company}}': 'WWE Corp',
+                '{{icebreaker}}': 'I loved your recent blog post!'
+            };
 
+            document.getElementById('tab-preview').addEventListener('click', () => {
+                document.getElementById('tab-preview').classList.replace('btn-outline-secondary', 'btn-primary');
+                document.getElementById('tab-edit').classList.replace('btn-primary', 'btn-outline-secondary');
+                document.getElementById('edit-view').classList.add('d-none');
+                document.getElementById('preview-view').classList.remove('d-none');
+                
+                let preview = document.getElementById('ep-body').value;
+                Object.entries(MOCK_DATA).forEach(([tag, value]) => {
+                    preview = preview.replaceAll(tag, value);
+                });
+                document.getElementById('email-preview-box').textContent = preview;
+            });
+
+            document.getElementById('tab-edit').addEventListener('click', () => {
+                document.getElementById('tab-edit').classList.replace('btn-outline-secondary', 'btn-primary');
+                document.getElementById('tab-preview').classList.replace('btn-primary', 'btn-outline-secondary');
+                document.getElementById('preview-view').classList.add('d-none');
+                document.getElementById('edit-view').classList.remove('d-none');
+            });
             let activeEditor = document.getElementById('ep-body');
 
             document.getElementById('ep-subject').addEventListener('focus', () => {


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #449 

---

## 📝 Summary of Changes

- Added two tabs ("Edit Template" and "Preview Email") to the sequence step email editor in frontend/campaign-builder.html
- When "Preview Email" tab is clicked, reads the textarea content and replaces merge tags ({{firstName}}, {{lastName}}, {{email}}, {{company}}, {{icebreaker}}) with mock values so users can visualize the final email output before sending
- Switching back to "Edit Template" tab restores the editable textarea

---

## 🏷️ Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

Tested locally in the browser.

Steps to test:

1. Open the campaign builder and click on an email step
2. Type an email body using merge tags e.g. Hi {{firstName}}, reaching out to you at {{company}}
3. Click the "Preview Email" tab
4. Verify merge tags are replaced with mock values (John Cena, WWE etc.)
5. Click "Edit Template" to switch back and verify the original content is preserved

---

## 📸 Screenshots (if applicable)

<img width="2877" height="1530" alt="image" src="https://github.com/user-attachments/assets/25964246-841a-4584-a6e1-512e94693b29" />


---

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [x] Related issue linked
* [x] Changes tested locally (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Edit Template and Preview Email tabs to the email body editor.
  * Added an email preview that displays merge tags with sample values.
  * Added quick switching between editing and preview modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->