### PR TITLE
fix(leads): Add file size validation to CSV import endpoint (LO-079)

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -236,3 +236,8 @@ GOOGLE_SCOPES = [
 TWILIO_ACCOUNT_SID = os.getenv('TWILIO_ACCOUNT_SID', _read_local_env_value('TWILIO_ACCOUNT_SID', ''))
 TWILIO_AUTH_TOKEN = os.getenv('TWILIO_AUTH_TOKEN', _read_local_env_value('TWILIO_AUTH_TOKEN', ''))
 TWILIO_PHONE_NUMBER = os.getenv('TWILIO_PHONE_NUMBER', _read_local_env_value('TWILIO_PHONE_NUMBER', ''))
+
+# ─── File Upload Limits ─────────────────────────────
+# Maximum size allowed for CSV uploads (default 10MB)
+MAX_CSV_UPLOAD_SIZE = int(os.getenv('MAX_CSV_UPLOAD_SIZE', 10 * 1024 * 1024))
+

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -118,3 +118,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 
 STATIC_URL = "static/"
+
+# Maximum size allowed for CSV uploads (default 10MB)
+MAX_CSV_UPLOAD_SIZE = int(os.getenv('MAX_CSV_UPLOAD_SIZE', 10 * 1024 * 1024))
+

--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -201,6 +201,39 @@ class LeadIsolationAPITests(APITestCase):
         self.assertFalse(Lead.objects.filter(organization=self.org_a).exists())
         self.assertTrue(Lead.objects.filter(id=self.lead_b.id).exists())
 
+    def test_import_csv_oversized_file_rejected(self):
+        self.client.force_authenticate(self.user_a)
+        with self.settings(MAX_CSV_UPLOAD_SIZE=50):
+            file_data = b"email,first_name,last_name\n" + b"a" * 100 + b"@example.com,John,Doe\n"
+            oversized_file = SimpleUploadedFile(
+                "too_large.csv",
+                file_data,
+                content_type="text/csv"
+            )
+            response = self.client.post(
+                '/api/v1/leads/import_csv/',
+                {'file': oversized_file},
+                format='multipart'
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertIn("File size exceeds the limit", response.data['error'])
+
+    def test_import_csv_normal_size_file_accepted(self):
+        self.client.force_authenticate(self.user_a)
+        with self.settings(MAX_CSV_UPLOAD_SIZE=1000):
+            file_data = b"email,first_name,last_name\n" + b"john@example.com,John,Doe\n"
+            normal_file = SimpleUploadedFile(
+                "normal.csv",
+                file_data,
+                content_type="text/csv"
+            )
+            response = self.client.post(
+                '/api/v1/leads/import_csv/',
+                {'file': normal_file},
+                format='multipart'
+            )
+            self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
     def test_blocked_domain_create_normalizes_domain_for_current_organization(self):
         self.client.force_authenticate(self.user_a)
 

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -97,6 +97,15 @@ class LeadViewSet(viewsets.ModelViewSet):
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
 
+        from django.conf import settings
+        max_size = getattr(settings, 'MAX_CSV_UPLOAD_SIZE', 10 * 1024 * 1024)
+        if file_obj.size > max_size:
+            return Response(
+                {"error": f"File size exceeds the limit of {max_size / (1024 * 1024):.1f}MB."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+
         job = LeadImportJob.objects.create(
             organization=request.user.organization,
             filename=file_obj.name or 'lead-import.csv',


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #327

---

## 📝 Summary of Changes

* **Settings Configuration**: Added `MAX_CSV_UPLOAD_SIZE` setting to `backend/backend/settings.py` (defaulting to 10MB) to configure the maximum allowable size for uploaded CSV files.
* **View Validation**: Added validation inside `import_csv` in `backend/leads/views.py` to check `file_obj.size` against `MAX_CSV_UPLOAD_SIZE` before reading the file. If the file is oversized, it returns a `400 Bad Request` response, preventing memory exhaustion.
* **Regression Testing**: Added `test_import_csv_oversized_file_rejected` and `test_import_csv_normal_size_file_accepted` tests to `backend/leads/tests.py` to verify this behavior.

---

## 🏷️ Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

The changes were verified locally using the backend test suite.

**Steps to test:**
1. Navigate to the `backend` directory.
2. Run the command: `python manage.py test leads`
3. Verify that the 34 tests (including our new size-validation tests) execute and pass successfully.

---

## 📸 Screenshots (if applicable)

*N/A (Backend logic changes only)*

---

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [x] Related issue linked
* [x] Changes tested locally (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum file size for CSV uploads, defaulting to 10 MB.
  * CSV files exceeding the configured limit are rejected with a clear error message.
  * Valid CSV files continue to be accepted and processed asynchronously.

* **Bug Fixes**
  * Prevented oversized uploads from creating unnecessary import jobs or entering processing queues.

* **Tests**
  * Added coverage for both rejected oversized files and successfully accepted uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->