### PR TITLE
docs: add live website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 ![License](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![LastCommit](https://img.shields.io/github/last-commit/Kuldeeep18/LeadOrbit)
 ![Stars](https://img.shields.io/github/stars/Kuldeeep18/LeadOrbit)
+
+**Live Demo:** [https://leadorbit-1.onrender.com/login.html](https://leadorbit-1.onrender.com/login.html)
+
 Current branding note: the active app is branded as `LeadOrbit`; older planning documents in the repo may still mention the original `Lime` name.
 
 LeadOrbit is a multi-tenant outbound outreach MVP built with Django REST Framework and a static HTML/JavaScript frontend. The implemented code supports organization signup, JWT auth, CSV lead import, campaign building, lead enrollment, Gmail sender connection, AI-assisted email drafting, webhook-based engagement tracking, and analytics pages.
@@ -238,6 +241,8 @@ Current repo state: `27` backend tests pass. The suite covers auth/profile updat
 - If no AI credentials are configured, the campaign builder AI composer still returns a deterministic fallback draft instead of failing hard.
 
 # LeadOrbit
+
+**Live Demo:** [https://leadorbit-1.onrender.com/login.html](https://leadorbit-1.onrender.com/login.html)
 
 Current branding note: the active app is branded as `LeadOrbit`; older planning documents in the repo may still mention the original `Lime` name.
 


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue
#513 

Closes #<!-- Issue number -->
#513 

---

## 📝 Summary of Changes
Added the live deployment frontend website link directly to the repository's `README.md` file so contributors and users can easily access the running application interface.

<!-- Briefly describe the changes made in this PR -->

---

## 🏷️ Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] ♻️ Refactor
* [x] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

**Steps to test:**
1. Open the updated `README.md`.
2. Verify both added instances of the Live Demo link navigate directly to the active LeadOrbit frontend interface (`https://leadorbit-1.onrender.com/login.html`).


## 📸 Screenshots (if applicable)
<img width="1721" height="577" alt="image" src="https://github.com/user-attachments/assets/a0fcc550-24a6-4da2-a97a-7d621bbb0d56" />

---

## ✅ Checklist

* [x] No merge conflicts
* [x] Changes follow the project guidelines
* [x] Documentation updated (if applicable)
* [x] Related issue linked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Live Demo links to the README, making the deployed application easier to access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->