### PR TITLE
Fix : Add file size validation for CSV import endpoint

### DIFF
--- a/backend/leads/tests.py
+++ b/backend/leads/tests.py
@@ -1,6 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 from rest_framework.test import APITestCase
+from django.urls import reverse
 
 from leads.models import BlockedDomain, Lead, Tag, LeadTag, LeadImportJob
 from leads.tasks import import_leads_from_csv
@@ -225,6 +226,27 @@ class LeadIsolationAPITests(APITestCase):
         domains = {item['domain'] for item in response.data}
         self.assertEqual(domains, {'orga.test'})
 
+    def test_import_csv_rejects_oversized_file(self):
+        self.client.force_authenticate(self.user_a)
+
+        large_file = SimpleUploadedFile(
+            "large.csv", b"x" * (10 * 1024 * 1024 + 1),
+            content_type="text/csv",
+            )
+        url = reverse("leads-import-csv")
+        response = self.client.post(url,
+         {"file":large_file},
+         format="multipart",
+         )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "CSV file exceeds the 10 MB limit.")
+
+        self.assertEqual(   
+            LeadImportJob.objects.filter(organization=self.org_a).count(),
+            0,
+        )
+
     def test_import_history_endpoint_is_scoped_and_paginated(self):
         LeadImportJob.objects.create(
             organization=self.org_a,
@@ -250,6 +272,8 @@ class LeadIsolationAPITests(APITestCase):
         self.assertIn('results', response.data)
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['filename'], 'orga.csv')
+
+
 
 
 # ── New tests for Issue #244 ───────────────────────────────────────────────────

--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -4,6 +4,9 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from users.permissions import IsOrgManager
+# Maximum allowed CSV upload size (10 MB)
+MAX_CSV_UPLOAD_SIZE = 10 * 1024 * 1024
+
 from .models import BlockedDomain, Lead, LeadImportJob, Tag, LeadTag
 from .serializers import BlockedDomainSerializer, LeadImportJobSerializer, LeadSerializer, TagSerializer
 
@@ -97,6 +100,10 @@ class LeadViewSet(viewsets.ModelViewSet):
         if not file_obj:
             return Response({"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
 
+        if file_obj.size > MAX_CSV_UPLOAD_SIZE:
+            return Response(
+                {"error": "CSV file exceeds the 10 MB limit."},status=status.HTTP_400_BAD_REQUEST,
+            )
         job = LeadImportJob.objects.create(
             organization=request.user.organization,
             filename=file_obj.name or 'lead-import.csv',


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #327 

---

## 📝 Summary of Changes

- Added a maximum CSV upload size limit of 10 MB.
- Added  validation to reject oversize CSV upload before reading the file into memory.
- Return HTTP 400 Bad Request with a appropriate error message when upload exceeds the allowed limit.
- Added a test to verify oversize CSV file uploads are rejected.
---

## 🏷️ Type of Change

* [☑️] 🐛 Bug fix
* [] ✨ New feature
* [ ] ♻️ Refactor
* [ ] 📝 Documentation update
* [ ] 🎨 UI / Style change
* [ ] 🔧 Chore

---

## 🧪 Testing

<!-- Describe how the changes were tested -->

**Steps to test:**
1 .Upload CSV file larger than 10 MB
2. Verify the API returns HTTP 400 with expected error message.
3. Upload a CSV file smaller than 10 MB and verify it is accepted.
4. Run: python manage.py test leads.tests

---

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI-related changes -->

---

## ✅ Checklist

* [ ✅] No merge conflicts
* [ ✅] Changes follow the project guidelines
* [ ] Documentation updated (if applicable)
* [ ✅] Related issue linked
* [ ✅] Changes tested locally (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV lead imports larger than 10 MB are now rejected with a clear error message.
  * Oversized uploads no longer create import jobs or start processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->