### PR TITLE
sec: Rate limiting on Auth endpoints

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -142,7 +142,10 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
-    )
+    ),
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '5/min',
+    }
 }
 
 # Celery Configuration

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -6,8 +6,11 @@ from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.views import TokenObtainPairView as BaseTokenObtainPairView
 from users.jwt import CustomTokenObtainSerializer
 
+from rest_framework.throttling import AnonRateThrottle
+
 class CustomTokenObtainPairView(BaseTokenObtainPairView):
     serializer_class = CustomTokenObtainSerializer
+    throttle_classes = [AnonRateThrottle]
 
 from users.views import AuthViewSet
 from leads.views import BlockedDomainViewSet, LeadImportJobViewSet, LeadViewSet, TagViewSet

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -8,9 +8,10 @@ from .models import User
 from .permissions import IsOrgAdmin
 from .serializers import UserSerializer, RegisterSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework.throttling import AnonRateThrottle
 
 class AuthViewSet(viewsets.GenericViewSet):
-    @action(detail=False, methods=['post'], permission_classes=[AllowAny])
+    @action(detail=False, methods=['post'], permission_classes=[AllowAny], throttle_classes=[AnonRateThrottle])
     def register(self, request):
         serializer = RegisterSerializer(data=request.data)
         if serializer.is_valid():


### PR DESCRIPTION
Fixes #666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Added rate limiting for anonymous API requests, allowing up to 5 requests per minute.
  * Applied throttling to login and account registration requests to help prevent abuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->