### PR TITLE
feat: Allow exporting leads to CSV (Fixes #657)

### DIFF
--- a/backend/leads/views.py
+++ b/backend/leads/views.py
@@ -1,4 +1,6 @@
 from django.db.models import Q
+from django.http import HttpResponse
+import csv
 from rest_framework import viewsets, parsers, status
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.decorators import action
@@ -90,6 +92,28 @@ class LeadViewSet(viewsets.ModelViewSet):
             {"message": f"Successfully deleted {deleted_count} leads."},
             status=status.HTTP_200_OK,
         )
+
+    @action(detail=False, methods=['get'])
+    def export(self, request):
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="leads.csv"'
+        
+        writer = csv.writer(response)
+        writer.writerow(['Email', 'First Name', 'Last Name', 'Company', 'Phone', 'LinkedIn', 'Created At'])
+        
+        leads = self.get_queryset()
+        for lead in leads:
+            writer.writerow([
+                lead.email,
+                lead.first_name,
+                lead.last_name,
+                lead.company,
+                lead.phone,
+                lead.linkedin_url,
+                lead.created_at.strftime('%Y-%m-%d %H:%M:%S')
+            ])
+            
+        return response
 
     @action(detail=False, methods=['post'], parser_classes=[parsers.MultiPartParser])
     def import_csv(self, request):

--- a/frontend/leads.html
+++ b/frontend/leads.html
@@ -200,6 +200,9 @@
                             <i class="bi bi-funnel me-1" aria-hidden="true"></i>Filters
                             <span class="filter-dot" id="filter-active-dot" aria-hidden="true"></span>
                         </button>
+                        <button class="btn btn-sm btn-outline-success" id="export-csv-btn">
+                            <i class="bi bi-download me-1" aria-hidden="true"></i> Export CSV
+                        </button>
                         <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#uploadModal">
                             <i class="bi bi-upload me-1" aria-hidden="true"></i> Import CSV
                         </button>
@@ -820,6 +823,54 @@
                 await loadImportHistory();
             } catch (e) {
                 console.error('Error fetching leads:', e);
+            }
+
+            // Export to CSV Logic
+            const exportBtn = document.getElementById('export-csv-btn');
+            if (exportBtn) {
+                exportBtn.addEventListener('click', async () => {
+                    const originalText = exportBtn.innerHTML;
+                    exportBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>Exporting...';
+                    exportBtn.disabled = true;
+                    try {
+                        const token = localStorage.getItem('access_token');
+                        const response = await fetch('http://localhost:8000/api/v1/leads/export/', {
+                            method: 'GET',
+                            headers: {
+                                'Authorization': `Bearer ${token}`
+                            }
+                        });
+                        
+                        if (!response.ok) {
+                            throw new Error('Export failed');
+                        }
+                        
+                        const blob = await response.blob();
+                        const url = window.URL.createObjectURL(blob);
+                        const a = document.createElement('a');
+                        a.style.display = 'none';
+                        a.href = url;
+                        // Determine filename from Content-Disposition if available
+                        let filename = 'leads.csv';
+                        const disposition = response.headers.get('Content-Disposition');
+                        if (disposition && disposition.indexOf('attachment') !== -1) {
+                            const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+                            const matches = filenameRegex.exec(disposition);
+                            if (matches != null && matches[1]) { 
+                                filename = matches[1].replace(/['"]/g, '');
+                            }
+                        }
+                        a.download = filename;
+                        document.body.appendChild(a);
+                        a.click();
+                        window.URL.revokeObjectURL(url);
+                    } catch (error) {
+                        alert(error.message || 'Could not export leads.');
+                    } finally {
+                        exportBtn.innerHTML = originalText;
+                        exportBtn.disabled = false;
+                    }
+                });
             }
 
             await loadTags();


### PR DESCRIPTION
Closes #657. Adds export endpoint to LeadViewSet and an Export button to the Leads UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Export CSV button to the leads toolbar.
  * Download leads, including contact and creation details, as a CSV file.
  * Added loading and error feedback during exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->