### PR TITLE
feat: add custom SMTP/IMAP account support

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -19,7 +19,7 @@ from campaigns.views import (
     AIGenerateView,
     unsubscribe_view
 )
-from campaigns.google_auth_views import GoogleOAuthLoginView, GoogleOAuthCallbackView, ConnectedAccountsListView
+from campaigns.google_auth_views import GoogleOAuthLoginView, GoogleOAuthCallbackView, ConnectedAccountsListView, TestConnectedAccountConnectionView
 
 
 def api_root(_request):
@@ -49,6 +49,7 @@ urlpatterns = [
     path('auth/google/login', GoogleOAuthLoginView.as_view(), name='google_oauth_login_fallback'),
     path('auth/google/callback', GoogleOAuthCallbackView.as_view(), name='google_oauth_callback_fallback'),
     path('api/v1/connected-accounts/', ConnectedAccountsListView.as_view(), name='connected_accounts'),
+    path('api/v1/connected-accounts/test-connection/', TestConnectedAccountConnectionView.as_view(), name='connected_account_test_connection'),
     path('api/v1/unsubscribe/<uuid:lead_id>/<str:token>/', unsubscribe_view, name='unsubscribe'),
     path('api/v1/', include(router.urls)),
 ]

--- a/backend/campaigns/google_auth_views.py
+++ b/backend/campaigns/google_auth_views.py
@@ -10,6 +10,8 @@ Architecture notes:
 """
 import json
 import logging
+import imaplib
+import smtplib
 import requests
 from urllib.parse import urlencode, urlparse
 
@@ -384,3 +386,67 @@ class ConnectedAccountsListView(APIView):
             for a in deduped
         ]
         return Response(data)
+
+
+class TestConnectedAccountConnectionView(APIView):
+    """
+    POST /api/v1/connected-accounts/test-connection/
+    Validates custom SMTP and IMAP credentials without saving them.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        payload = request.data or {}
+        smtp_error = self._test_smtp(payload)
+        imap_error = self._test_imap(payload)
+
+        if smtp_error or imap_error:
+            return Response(
+                {
+                    'connected': False,
+                    'smtp': {'ok': smtp_error is None, 'error': smtp_error},
+                    'imap': {'ok': imap_error is None, 'error': imap_error},
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response({'connected': True, 'smtp': {'ok': True}, 'imap': {'ok': True}})
+
+    def _test_smtp(self, payload):
+        host = (payload.get('smtp_host') or '').strip()
+        username = (payload.get('smtp_username') or '').strip()
+        password = payload.get('smtp_password') or ''
+        if not host or not username or not password:
+            return 'smtp_host, smtp_username, and smtp_password are required.'
+        try:
+            port = int(payload.get('smtp_port') or 587)
+            with smtplib.SMTP(host, port, timeout=10) as client:
+                if payload.get('smtp_use_tls', True):
+                    client.starttls()
+                client.login(username, password)
+        except (OSError, smtplib.SMTPException, ValueError) as exc:
+            return str(exc)
+        return None
+
+    def _test_imap(self, payload):
+        host = (payload.get('imap_host') or '').strip()
+        username = (payload.get('imap_username') or '').strip()
+        password = payload.get('imap_password') or ''
+        if not host or not username or not password:
+            return 'imap_host, imap_username, and imap_password are required.'
+        try:
+            port = int(payload.get('imap_port') or 993)
+            if payload.get('imap_use_ssl', True):
+                client = imaplib.IMAP4_SSL(host, port, timeout=10)
+            else:
+                client = imaplib.IMAP4(host, port, timeout=10)
+            try:
+                client.login(username, password)
+            finally:
+                try:
+                    client.logout()
+                except Exception:
+                    pass
+        except (OSError, imaplib.IMAP4.error, ValueError) as exc:
+            return str(exc)
+        return None

--- a/backend/campaigns/migrations/0007_custom_smtp_imap_fields.py
+++ b/backend/campaigns/migrations/0007_custom_smtp_imap_fields.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0006_alter_sequencestep_channel_type'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='connectedemailaccount',
+            name='provider',
+            field=models.CharField(
+                choices=[
+                    ('GOOGLE', 'Google'),
+                    ('MICROSOFT', 'Microsoft'),
+                    ('SMTP', 'Custom SMTP/IMAP'),
+                ],
+                default='GOOGLE',
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(model_name='connectedemailaccount', name='smtp_host', field=models.CharField(blank=True, default='', max_length=255)),
+        migrations.AddField(model_name='connectedemailaccount', name='smtp_port', field=models.PositiveIntegerField(blank=True, null=True)),
+        migrations.AddField(model_name='connectedemailaccount', name='smtp_username', field=models.CharField(blank=True, default='', max_length=255)),
+        migrations.AddField(model_name='connectedemailaccount', name='smtp_password', field=models.TextField(blank=True, default='')),
+        migrations.AddField(model_name='connectedemailaccount', name='smtp_use_tls', field=models.BooleanField(default=True)),
+        migrations.AddField(model_name='connectedemailaccount', name='imap_host', field=models.CharField(blank=True, default='', max_length=255)),
+        migrations.AddField(model_name='connectedemailaccount', name='imap_port', field=models.PositiveIntegerField(blank=True, null=True)),
+        migrations.AddField(model_name='connectedemailaccount', name='imap_username', field=models.CharField(blank=True, default='', max_length=255)),
+        migrations.AddField(model_name='connectedemailaccount', name='imap_password', field=models.TextField(blank=True, default='')),
+        migrations.AddField(model_name='connectedemailaccount', name='imap_use_ssl', field=models.BooleanField(default=True)),
+    ]

--- a/backend/campaigns/models.py
+++ b/backend/campaigns/models.py
@@ -7,7 +7,8 @@ import uuid
 class ConnectedEmailAccount(TenantModel):
     PROVIDER_CHOICES = (
         ('GOOGLE', 'Google'),
-        ('MICROSOFT', 'Microsoft')
+        ('MICROSOFT', 'Microsoft'),
+        ('SMTP', 'Custom SMTP/IMAP'),
     )
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     email_address = models.EmailField()
@@ -22,6 +23,16 @@ class ConnectedEmailAccount(TenantModel):
     access_token = models.TextField()
     refresh_token = models.TextField(blank=True, null=True)
     token_expiry = models.DateTimeField(null=True, blank=True)
+    smtp_host = models.CharField(max_length=255, blank=True, default='')
+    smtp_port = models.PositiveIntegerField(null=True, blank=True)
+    smtp_username = models.CharField(max_length=255, blank=True, default='')
+    smtp_password = models.TextField(blank=True, default='')
+    smtp_use_tls = models.BooleanField(default=True)
+    imap_host = models.CharField(max_length=255, blank=True, default='')
+    imap_port = models.PositiveIntegerField(null=True, blank=True)
+    imap_username = models.CharField(max_length=255, blank=True, default='')
+    imap_password = models.TextField(blank=True, default='')
+    imap_use_ssl = models.BooleanField(default=True)
 
     def __str__(self):
         return f"{self.email_address} ({self.get_provider_display()})"

--- a/backend/campaigns/tasks.py
+++ b/backend/campaigns/tasks.py
@@ -1,5 +1,7 @@
 import logging
+import smtplib
 from datetime import timedelta
+from email.message import EmailMessage
 
 from celery import shared_task
 from django.conf import settings as django_settings
@@ -11,6 +13,28 @@ from .sms_service import send_sms, initiate_call
 from .models import CampaignLead, SequenceStep
 
 logger = logging.getLogger(__name__)
+
+
+def send_custom_smtp(account, to_email, subject, body_html, unsubscribe_url=None):
+    message = EmailMessage()
+    message['Subject'] = subject or ''
+    message['From'] = account.smtp_username or account.email_address
+    message['To'] = to_email
+    if unsubscribe_url:
+        message['List-Unsubscribe'] = f'<{unsubscribe_url}>'
+    message.set_content(body_html or '', subtype='html')
+
+    if not account.smtp_host or not account.smtp_port:
+        raise ValueError('Custom SMTP account is missing smtp_host or smtp_port.')
+
+    with smtplib.SMTP(account.smtp_host, account.smtp_port, timeout=15) as client:
+        if account.smtp_use_tls:
+            client.starttls()
+        if account.smtp_username:
+            client.login(account.smtp_username, account.smtp_password or '')
+        client.send_message(message)
+
+    return message.get('Message-ID') or f'smtp:{account.id}'
 
 def _get_campaign_steps(campaign):
     """
@@ -425,18 +449,27 @@ def send_email_step(campaign_lead_id, step_id):
         account = clead.campaign.connected_account
         if account:
             try:
-                message_id = send_gmail(
-                    account,
-                    clead.lead.email,
-                    subject,
-                    body,
-                    unsubscribe_url=build_unsubscribe_url(clead.lead),
-                )
+                if account.provider == 'SMTP':
+                    message_id = send_custom_smtp(
+                        account,
+                        clead.lead.email,
+                        subject,
+                        body,
+                        unsubscribe_url=build_unsubscribe_url(clead.lead),
+                    )
+                else:
+                    message_id = send_gmail(
+                        account,
+                        clead.lead.email,
+                        subject,
+                        body,
+                        unsubscribe_url=build_unsubscribe_url(clead.lead),
+                    )
                 clead.last_sent_message_id = message_id
                 clead.save(update_fields=['last_sent_message_id'])
-                logger.info(f"Gmail SENT to {clead.lead.email} | msg_id={message_id}")
-            except Exception as gmail_err:
-                logger.error(f"Gmail API send failed for {clead.lead.email}: {gmail_err}")
+                logger.info(f"{account.provider} SENT to {clead.lead.email} | msg_id={message_id}")
+            except Exception as send_err:
+                logger.error(f"{account.provider} send failed for {clead.lead.email}: {send_err}")
                 # Restore next_execution_time so the lead can be retried later.
                 clead.next_execution_time = timezone.now() + timedelta(minutes=15)
                 clead.save(update_fields=['next_execution_time'])

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -32,6 +32,91 @@ class CampaignWorkflowTests(APITestCase):
         )
         self.client.force_authenticate(self.user)
 
+    @patch('campaigns.google_auth_views.imaplib.IMAP4_SSL')
+    @patch('campaigns.google_auth_views.smtplib.SMTP')
+    def test_custom_smtp_imap_connection_endpoint_validates_credentials(self, mock_smtp, mock_imap):
+        payload = {
+            'smtp_host': 'smtp.example.com',
+            'smtp_port': 587,
+            'smtp_username': 'sender@example.com',
+            'smtp_password': 'secret',
+            'smtp_use_tls': True,
+            'imap_host': 'imap.example.com',
+            'imap_port': 993,
+            'imap_username': 'sender@example.com',
+            'imap_password': 'secret',
+            'imap_use_ssl': True,
+        }
+
+        response = self.client.post(
+            '/api/v1/connected-accounts/test-connection/',
+            payload,
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['connected'])
+        mock_smtp.return_value.__enter__.return_value.starttls.assert_called_once()
+        mock_smtp.return_value.__enter__.return_value.login.assert_called_once_with(
+            'sender@example.com',
+            'secret',
+        )
+        mock_imap.return_value.login.assert_called_once_with('sender@example.com', 'secret')
+
+    @patch('campaigns.tasks.smtplib.SMTP')
+    def test_send_email_step_uses_custom_smtp_provider(self, mock_smtp):
+        account = ConnectedEmailAccount.objects.create(
+            organization=self.organization,
+            connected_by=self.user,
+            email_address='sender@example.com',
+            provider='SMTP',
+            access_token='',
+            smtp_host='smtp.example.com',
+            smtp_port=587,
+            smtp_username='sender@example.com',
+            smtp_password='secret',
+            imap_host='imap.example.com',
+            imap_port=993,
+            imap_username='sender@example.com',
+            imap_password='secret',
+        )
+        campaign = Campaign.objects.create(
+            organization=self.organization,
+            name='Custom SMTP campaign',
+            status='ACTIVE',
+            connected_account=account,
+        )
+        step = SequenceStep.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            step_order=1,
+            channel_type='EMAIL',
+            template_subject='Hello {{firstName}}',
+            template_body='Hi {{firstName}}',
+        )
+        lead = Lead.objects.create(
+            organization=self.organization,
+            email='lead@example.com',
+            first_name='Lead',
+        )
+        campaign_lead = CampaignLead.objects.create(
+            organization=self.organization,
+            campaign=campaign,
+            lead=lead,
+            current_step=step,
+            next_execution_time=timezone.now(),
+        )
+
+        send_email_step(campaign_lead.id, step.id)
+
+        smtp_client = mock_smtp.return_value.__enter__.return_value
+        mock_smtp.assert_called_once_with('smtp.example.com', 587, timeout=15)
+        smtp_client.starttls.assert_called_once()
+        smtp_client.login.assert_called_once_with('sender@example.com', 'secret')
+        smtp_client.send_message.assert_called_once()
+        campaign_lead.refresh_from_db()
+        self.assertTrue(campaign_lead.last_sent_message_id.startswith('smtp:'))
+
     def test_create_campaign_syncs_sequence_steps_from_builder_payload(self):
         account = ConnectedEmailAccount.objects.create(
             organization=self.organization,


### PR DESCRIPTION
## What changed
- Added custom SMTP/IMAP provider fields to connected email accounts.
- Added `/api/v1/connected-accounts/test-connection/` to validate SMTP auth and IMAP login before saving credentials.
- Routed `SMTP` connected accounts through a `smtplib` sender while keeping Gmail behavior unchanged.
- Added focused tests for connection validation and SMTP dispatch.

## Why
Businesses using Microsoft 365, Zoho, or custom domains need non-Google sender support.

## How to test
- `python -m py_compile backend/campaigns/models.py backend/campaigns/google_auth_views.py backend/campaigns/tasks.py backend/campaigns/tests.py`
- Full Django tests were not run locally because Django is not installed in this environment.

Closes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting custom SMTP/IMAP email accounts.
  * Added connection testing with validation for credentials, ports, and security settings.
  * Added SMTP-based campaign email delivery, including TLS, authentication, unsubscribe headers, and message tracking.
* **Bug Fixes**
  * Improved email delivery reliability with provider-specific handling, timeouts, cleanup, and retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->