### PR TITLE
feat: add custom mailbox connection test endpoint

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -27,6 +27,7 @@ from campaigns.google_auth_views import (
     GoogleOAuthLoginView,
     GoogleOAuthCallbackView,
     ConnectedAccountsListView,
+    ConnectedAccountConnectionTestView,
     ConnectedAccountDetailView,
 )
 
@@ -66,6 +67,7 @@ urlpatterns = [
     path('auth/google/login', GoogleOAuthLoginView.as_view(), name='google_oauth_login_fallback'),
     path('auth/google/callback', GoogleOAuthCallbackView.as_view(), name='google_oauth_callback_fallback'),
     path('api/v1/connected-accounts/', ConnectedAccountsListView.as_view(), name='connected_accounts'),
+    path('api/v1/connected-accounts/test-connection/', ConnectedAccountConnectionTestView.as_view(), name='connected_account_connection_test'),
     path('api/v1/connected-accounts/<uuid:account_id>/', ConnectedAccountDetailView.as_view(), name='connected_account_detail'),
     path('api/v1/unsubscribe/<uuid:lead_id>/<str:token>/', unsubscribe_view, name='unsubscribe'),
     path('api/v1/', include(router.urls)),

--- a/backend/campaigns/google_auth_views.py
+++ b/backend/campaigns/google_auth_views.py
@@ -26,6 +26,7 @@ from rest_framework import serializers, status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from .models import ConnectedEmailAccount
+from .mailbox_service import test_mailbox_connection
 
 logger = logging.getLogger(__name__)
 
@@ -485,6 +486,48 @@ class ConnectedAccountsListView(APIView):
             _serialize_connected_account(account),
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
         )
+
+
+class ConnectedAccountConnectionTestView(APIView):
+    """
+    POST /api/v1/connected-accounts/test-connection/
+    Verifies SMTP auth and IMAP login without saving the mailbox.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = CustomMailboxAccountSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = serializer.validated_data
+
+        account = ConnectedEmailAccount(
+            organization=request.user.organization,
+            connected_by=request.user,
+            provider='CUSTOM',
+            email_address=payload['email_address'],
+            smtp_host=payload['smtp_host'].strip(),
+            smtp_port=payload['smtp_port'],
+            smtp_username=payload['smtp_username'],
+            smtp_password=payload['smtp_password'],
+            smtp_use_tls=payload.get('smtp_use_tls', True),
+            smtp_use_ssl=payload.get('smtp_use_ssl', False),
+            imap_host=payload['imap_host'].strip(),
+            imap_port=payload['imap_port'],
+            imap_username=payload['imap_username'],
+            imap_password=payload['imap_password'],
+            imap_use_ssl=payload.get('imap_use_ssl', True),
+        )
+
+        try:
+            checks = test_mailbox_connection(account)
+        except Exception as exc:
+            logger.warning("[ConnectedAccounts] Custom mailbox connection test failed: %s", exc)
+            return Response(
+                {'detail': 'Could not connect to the custom mailbox with the supplied settings.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response({'email': account.email_address, 'checks': checks}, status=status.HTTP_200_OK)
 
 
 class ConnectedAccountDetailView(APIView):

--- a/backend/campaigns/mailbox_service.py
+++ b/backend/campaigns/mailbox_service.py
@@ -105,6 +105,29 @@ def _connect_imap(account):
     return client
 
 
+def test_mailbox_connection(account):
+    """Verify both SMTP and IMAP credentials for a custom mailbox."""
+    smtp_client = _connect_smtp(account)
+    try:
+        smtp_client.noop()
+    finally:
+        try:
+            smtp_client.quit()
+        except Exception:
+            smtp_client.close()
+
+    imap_client = _connect_imap(account)
+    try:
+        imap_client.noop()
+    finally:
+        imap_client.logout()
+
+    return {
+        'smtp': 'connected',
+        'imap': 'connected',
+    }
+
+
 def _looks_like_bounce(message):
     """Heuristically identify common bounce messages from subject or sender."""
     subject = str(message.get('Subject', '') or '').lower()

--- a/backend/campaigns/tests.py
+++ b/backend/campaigns/tests.py
@@ -124,6 +124,55 @@ class CampaignWorkflowTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('smtp_use_tls', response.data)
 
+    def test_custom_connected_account_test_connection_verifies_without_saving(self):
+        payload = {
+            'email_address': 'probe-sender@acme.test',
+            'smtp_host': 'smtp.acme.test',
+            'smtp_port': 587,
+            'smtp_username': 'smtp-user',
+            'smtp_password': 'smtp-pass',
+            'smtp_use_tls': True,
+            'smtp_use_ssl': False,
+            'imap_host': 'imap.acme.test',
+            'imap_port': 993,
+            'imap_username': 'imap-user',
+            'imap_password': 'imap-pass',
+            'imap_use_ssl': True,
+        }
+
+        with patch(
+            'campaigns.google_auth_views.test_mailbox_connection',
+            return_value={'smtp': 'connected', 'imap': 'connected'},
+        ) as mocked_test:
+            response = self.client.post('/api/v1/connected-accounts/test-connection/', payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['checks']['smtp'], 'connected')
+        self.assertFalse(ConnectedEmailAccount.objects.filter(email_address='probe-sender@acme.test').exists())
+        mocked_test.assert_called_once()
+
+    def test_custom_connected_account_test_connection_returns_validation_error(self):
+        payload = {
+            'email_address': 'probe-sender@acme.test',
+            'smtp_host': 'smtp.acme.test',
+            'smtp_port': 587,
+            'smtp_username': 'smtp-user',
+            'smtp_password': 'smtp-pass',
+            'smtp_use_tls': True,
+            'smtp_use_ssl': False,
+            'imap_host': 'imap.acme.test',
+            'imap_port': 993,
+            'imap_username': 'imap-user',
+            'imap_password': 'imap-pass',
+            'imap_use_ssl': True,
+        }
+
+        with patch('campaigns.google_auth_views.test_mailbox_connection', side_effect=OSError('auth failed')):
+            response = self.client.post('/api/v1/connected-accounts/test-connection/', payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('detail', response.data)
+
     def test_custom_connected_account_passwords_are_encrypted_at_rest(self):
         payload = {
             'email_address': 'encrypted-sender@acme.test',


### PR DESCRIPTION
## Summary
- adds POST /api/v1/connected-accounts/test-connection/ for custom SMTP/IMAP credentials
- verifies SMTP auth and IMAP login without saving the mailbox
- covers success and connection-failure API behavior

Closes #192

## Validation
- python -m py_compile backend/campaigns/mailbox_service.py backend/campaigns/google_auth_views.py backend/backend/urls.py backend/campaigns/tests.py
- Django focused tests attempted locally but blocked by missing Django dependency: No module named 'django'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to test custom mailbox connections before saving account settings.
  * Connection checks now verify both SMTP and IMAP access and report each result.

* **Bug Fixes**
  * Improved handling of invalid mailbox credentials with a clear validation error.
  * Ensured connection tests do not save account settings when verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->