### PR TITLE
fix: auto-capitalize lead first and last names on save (#703)

### DIFF
--- a/backend/leads/models.py
+++ b/backend/leads/models.py
@@ -41,6 +41,13 @@ class Lead(TenantModel):
     def __str__(self):
         return f"{self.first_name} {self.last_name} ({self.email})"
 
+    def save(self, *args, **kwargs):
+        if self.first_name:
+            self.first_name = self.first_name.strip().title()
+        if self.last_name:
+            self.last_name = self.last_name.strip().title()
+        super().save(*args, **kwargs)
+
 class LeadImportJob(TenantModel):
     filename = models.CharField(max_length=255)
     total_rows = models.IntegerField(default=0)


### PR DESCRIPTION
## Summary
Auto-capitalizes lead first_name and last_name upon model save so merge tags render as "Hi John" instead of "Hi john".

## Changes
- Added `save()` override to `Lead` model that applies `.strip().title()` to first_name and last_name
- Handles None/empty values safely
- Works for both manual creation and CSV imports

## Why
When leads are imported or added with lowercase names, personalize merge tags render unprofessionally. This ensures outreach emails always look polished.

Closes #703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lead first and last names are now automatically trimmed and formatted consistently when saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->